### PR TITLE
feat(profile): restructure profile sections and account panel (#132)

### DIFF
--- a/src/features/customer/profile/components/AccountSection.tsx
+++ b/src/features/customer/profile/components/AccountSection.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { Icons } from './Icons';
+import { SettingItem } from './SettingItem';
+import { SectionHeading } from './SectionHeading';
+
+interface AccountSectionProps {
+  onAccountSecurity: () => void;
+  onNotification: () => void;
+  onStorage: () => void;
+  onSupport: () => void;
+  onLogout: () => void;
+}
+
+export const AccountSection: React.FC<AccountSectionProps> = ({
+  onAccountSecurity,
+  onNotification,
+  onStorage,
+  onSupport,
+  onLogout,
+}) => {
+  return (
+    <section>
+      <SectionHeading icon={<Icons.User />} title="Account" />
+      <div className="bg-white rounded-2xl overflow-hidden shadow-sm border border-gray-100">
+        <div onClick={onAccountSecurity}>
+          <SettingItem icon={<Icons.Shield />} label="account security" />
+        </div>
+        <div onClick={onNotification}>
+          <SettingItem icon={<Icons.Bell />} label="notification" />
+        </div>
+        <div onClick={onStorage}>
+          <SettingItem icon={<Icons.Bookmark />} label="storage" />
+        </div>
+        <div onClick={onSupport}>
+          <SettingItem icon={<Icons.HelpCircle />} label="support" />
+        </div>
+        <div className="h-[1px] bg-gray-100 mx-5 my-1"></div>
+        <div onClick={onLogout}>
+          <SettingItem icon={<Icons.LogOut />} label="logout" isDestructive />
+        </div>
+      </div>
+      <p className="text-xs text-gray-400 mt-3 px-2">waitting for extending</p>
+    </section>
+  );
+};

--- a/src/features/customer/profile/components/MyHistorySection.tsx
+++ b/src/features/customer/profile/components/MyHistorySection.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import { Review } from '../types';
+import { Icons } from './Icons';
+import { SectionHeading } from './SectionHeading';
+
+interface MyHistorySectionProps {
+  latestReview: Review | null;
+  loading?: boolean;
+  onViewAllReviews: () => void;
+}
+
+export const MyHistorySection: React.FC<MyHistorySectionProps> = ({
+  latestReview,
+  loading = false,
+  onViewAllReviews,
+}) => {
+  return (
+    <section className="animate-fade-in-up" style={{ animationDelay: '0.28s' }}>
+      <SectionHeading icon={<Icons.Clock />} title="My History" />
+
+      <article className="rounded-[24px] border border-gray-100 bg-white p-5 shadow-[0_10px_30px_-15px_rgba(17,24,39,0.35)]">
+        {loading && (
+          <div className="flex items-center justify-center py-6">
+            <div className="animate-spin rounded-full h-7 w-7 border-b-2 border-brand-red"></div>
+          </div>
+        )}
+
+        {!loading && latestReview && (
+          <div className="flex items-start gap-4">
+            <img
+              src={latestReview.businessImage}
+              alt={latestReview.businessName}
+              className="h-14 w-14 rounded-2xl object-cover border border-gray-100"
+            />
+            <div className="min-w-0 flex-1">
+              <div className="flex items-start justify-between gap-3">
+                <div>
+                  <h3 className="text-[17px] font-bold text-gray-900 leading-tight">{latestReview.businessName}</h3>
+                  <p className="mt-1 text-xs font-medium text-gray-500">{latestReview.date}</p>
+                </div>
+                <button
+                  type="button"
+                  aria-label="View all reviews"
+                  onClick={onViewAllReviews}
+                  className="h-8 w-8 rounded-full border border-gray-200 text-gray-500 flex items-center justify-center hover:text-brand-red hover:border-brand-red/30 transition-colors"
+                >
+                  <Icons.ChevronRight size={16} />
+                </button>
+              </div>
+              <p className="mt-3 text-sm text-gray-600 line-clamp-2">{latestReview.content}</p>
+            </div>
+          </div>
+        )}
+
+        {!loading && !latestReview && (
+          <div className="flex items-center justify-between gap-4">
+            <p className="text-sm text-gray-500">No review history yet.</p>
+            <button
+              type="button"
+              aria-label="View all reviews"
+              onClick={onViewAllReviews}
+              className="h-8 w-8 rounded-full border border-gray-200 text-gray-500 flex items-center justify-center hover:text-brand-red hover:border-brand-red/30 transition-colors"
+            >
+              <Icons.ChevronRight size={16} />
+            </button>
+          </div>
+        )}
+      </article>
+    </section>
+  );
+};

--- a/src/features/customer/profile/components/PendingReviewMerchants.tsx
+++ b/src/features/customer/profile/components/PendingReviewMerchants.tsx
@@ -1,0 +1,85 @@
+import React from 'react';
+import { PendingReviewMerchant } from '../types';
+import { Icons } from './Icons';
+import { SectionHeading } from './SectionHeading';
+
+interface PendingReviewMerchantsProps {
+  merchants: PendingReviewMerchant[];
+  loading?: boolean;
+  onWriteReview: (merchant: PendingReviewMerchant) => void;
+}
+
+export const PendingReviewMerchants: React.FC<PendingReviewMerchantsProps> = ({
+  merchants,
+  loading = false,
+  onWriteReview,
+}) => {
+  return (
+    <section className="animate-fade-in-up" style={{ animationDelay: '0.1s' }}>
+      <SectionHeading icon={<Icons.ShoppingBag />} title="Laet Merchant I Visit" />
+      <p className="-mt-2 mb-5 text-sm text-gray-500">Places you visited but still have not reviewed.</p>
+
+      {loading && (
+        <div className="rounded-[24px] bg-white/90 border border-gray-100 p-8 flex items-center justify-center">
+          <div className="animate-spin rounded-full h-7 w-7 border-b-2 border-brand-red"></div>
+        </div>
+      )}
+
+      {!loading && merchants.length === 0 && (
+        <div className="rounded-[24px] bg-white p-7 border border-gray-100 text-center">
+          <h3 className="text-lg font-bold text-gray-900">All caught up</h3>
+          <p className="mt-1 text-sm text-gray-500">No pending merchant reviews right now.</p>
+        </div>
+      )}
+
+      {!loading && merchants.length > 0 && (
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-5">
+          {merchants.map((merchant) => (
+            <article
+              key={merchant.id}
+              className="relative overflow-hidden rounded-[24px] border border-gray-100 bg-white p-5 shadow-[0_8px_28px_-14px_rgba(17,24,39,0.2)] transition-all hover:-translate-y-0.5 hover:shadow-[0_14px_34px_-14px_rgba(17,24,39,0.35)]"
+            >
+              <div className="absolute -top-10 -right-6 h-24 w-24 rounded-full bg-brand-red/8 blur-2xl" />
+              <div className="relative z-10">
+                <div className="flex items-start gap-3">
+                  <img
+                    src={merchant.businessImage}
+                    alt={merchant.businessName}
+                    className="h-14 w-14 rounded-2xl object-cover border border-gray-100"
+                  />
+                  <div className="min-w-0">
+                    <h3 className="text-[17px] font-bold text-gray-900 leading-tight truncate">
+                      {merchant.businessName}
+                    </h3>
+                    <p className="mt-1 inline-flex items-center gap-1 text-xs font-semibold text-brand-red bg-brand-red/5 px-2 py-1 rounded-full">
+                      <Icons.Clock size={12} />
+                      Last visit: {merchant.lastVisitedAt}
+                    </p>
+                  </div>
+                </div>
+
+                <p className="mt-4 text-sm text-gray-600 leading-relaxed line-clamp-2">
+                  You ordered: {merchant.lastOrderItems.join(', ')}
+                </p>
+
+                <div className="mt-5 flex items-center justify-between">
+                  <span className="text-[11px] font-bold uppercase tracking-wide text-amber-700 bg-amber-50 px-2 py-1 rounded-full">
+                    Not reviewed yet
+                  </span>
+                  <button
+                    type="button"
+                    onClick={() => onWriteReview(merchant)}
+                    className="inline-flex items-center gap-2 rounded-full bg-gray-900 px-4 py-2 text-xs font-bold text-white transition-colors hover:bg-black"
+                  >
+                    Write Review
+                    <Icons.ChevronRight size={14} />
+                  </button>
+                </div>
+              </div>
+            </article>
+          ))}
+        </div>
+      )}
+    </section>
+  );
+};

--- a/src/features/customer/profile/components/SectionHeading.tsx
+++ b/src/features/customer/profile/components/SectionHeading.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+
+interface SectionHeadingProps {
+  icon: React.ReactNode;
+  title: string;
+  rightSlot?: React.ReactNode;
+}
+
+export const SectionHeading: React.FC<SectionHeadingProps> = ({ icon, title, rightSlot }) => {
+  return (
+    <div className="flex items-center justify-between mb-4">
+      <div className="flex items-center gap-3">
+        <div className="h-9 w-9 rounded-xl bg-gray-900 text-white flex items-center justify-center shadow-sm">
+          {React.cloneElement(icon as React.ReactElement<any>, { size: 16 })}
+        </div>
+        <h2 className="text-xl font-bold text-gray-900 tracking-tight">{title}</h2>
+      </div>
+      {rightSlot}
+    </div>
+  );
+};

--- a/src/features/customer/profile/components/StatsBar.tsx
+++ b/src/features/customer/profile/components/StatsBar.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { MessageSquare, Users } from 'lucide-react';
 import { UserStats } from '../types';
 
 interface StatsBarProps {
@@ -6,22 +7,52 @@ interface StatsBarProps {
 }
 
 const StatsBar: React.FC<StatsBarProps> = ({ stats }) => {
+  const metricButtons = [
+    {
+      key: 'reviews',
+      label: 'REVIEWS',
+      value: stats.totalReviews,
+      icon: MessageSquare,
+      surfaceClass:
+        'from-[#990000] via-[#B20000] to-[#7A0000] text-white shadow-[0_14px_26px_-14px_rgba(153,0,0,0.85)]',
+      glowClass: 'bg-[#FFCC00]/35',
+    },
+    {
+      key: 'following',
+      label: 'FOLLOWING',
+      value: stats.following,
+      icon: Users,
+      surfaceClass:
+        'from-[#1F2937] via-[#111827] to-[#0B1220] text-white shadow-[0_14px_28px_-14px_rgba(15,23,42,0.8)]',
+      glowClass: 'bg-[#7DD3FC]/30',
+    },
+  ];
+
   return (
-    <div className="flex justify-between items-center py-4 px-2 mx-1 border-t border-b border-gray-50">
-      <div className="flex flex-col items-center group cursor-pointer">
-        <span className="text-[19px] font-bold text-gray-900 group-hover:text-brand-red transition-colors">{stats.totalReviews}</span>
-        <span className="text-[10px] font-bold text-gray-400 uppercase tracking-wider mt-0.5">Reviews</span>
-      </div>
-      
-      <div className="flex flex-col items-center group cursor-pointer">
-        <span className="text-[19px] font-bold text-gray-900 group-hover:text-brand-red transition-colors">{stats.photosUploaded}</span>
-        <span className="text-[10px] font-bold text-gray-400 uppercase tracking-wider mt-0.5">Photos</span>
-      </div>
-      
-      <div className="flex flex-col items-center group cursor-pointer">
-        <span className="text-[19px] font-bold text-gray-900 group-hover:text-brand-red transition-colors">{stats.views}</span>
-        <span className="text-[10px] font-bold text-gray-400 uppercase tracking-wider mt-0.5">Views</span>
-      </div>
+    <div className="grid grid-cols-2 gap-3 mt-1">
+      {metricButtons.map((metric) => {
+        const Icon = metric.icon;
+
+        return (
+          <button
+            key={metric.key}
+            type="button"
+            className={`group relative overflow-hidden rounded-2xl bg-gradient-to-br px-4 py-3 text-left transition-all duration-300 hover:-translate-y-0.5 hover:scale-[1.01] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-red/30 ${metric.surfaceClass}`}
+          >
+            <div className={`pointer-events-none absolute -top-8 -right-6 h-20 w-20 rounded-full blur-2xl transition-transform duration-500 group-hover:scale-125 ${metric.glowClass}`} />
+            <div className="relative z-10 flex items-center justify-between">
+              <div>
+                <div className="text-[11px] font-bold uppercase tracking-[0.2em] text-white/80">{metric.label}</div>
+                <div className="mt-1 text-[25px] font-black leading-none tracking-tight text-white">{metric.value}</div>
+              </div>
+              <div className="rounded-xl border border-white/25 bg-white/15 p-2.5 backdrop-blur-sm transition-colors group-hover:bg-white/25">
+                <Icon size={16} className="text-white" />
+              </div>
+            </div>
+            <div className="pointer-events-none absolute inset-x-4 bottom-2 h-px bg-gradient-to-r from-white/0 via-white/45 to-white/0 opacity-70" />
+          </button>
+        );
+      })}
     </div>
   );
 };

--- a/src/features/customer/profile/components/__tests__/AccountSection.test.tsx
+++ b/src/features/customer/profile/components/__tests__/AccountSection.test.tsx
@@ -1,0 +1,29 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import { describe, expect, it, vi } from 'vitest';
+import { AccountSection } from '../AccountSection';
+
+describe('AccountSection', () => {
+  it('shows requested account items and waitting text', () => {
+    const handlers = {
+      onAccountSecurity: vi.fn(),
+      onNotification: vi.fn(),
+      onStorage: vi.fn(),
+      onSupport: vi.fn(),
+      onLogout: vi.fn(),
+    };
+
+    render(<AccountSection {...handlers} />);
+
+    expect(screen.getByText('Account')).toBeInTheDocument();
+    expect(screen.getByText('account security')).toBeInTheDocument();
+    expect(screen.getByText('notification')).toBeInTheDocument();
+    expect(screen.getByText('storage')).toBeInTheDocument();
+    expect(screen.getByText('support')).toBeInTheDocument();
+    expect(screen.getByText('logout')).toBeInTheDocument();
+    expect(screen.getByText('waitting for extending')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('logout'));
+    expect(handlers.onLogout).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/features/customer/profile/components/__tests__/MyHistorySection.test.tsx
+++ b/src/features/customer/profile/components/__tests__/MyHistorySection.test.tsx
@@ -1,0 +1,32 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import { describe, expect, it, vi } from 'vitest';
+import { MyHistorySection } from '../MyHistorySection';
+import { Review } from '../../types';
+
+describe('MyHistorySection', () => {
+  it('shows latest review card and opens all reviews when clicking arrow button', () => {
+    const latestReview: Review = {
+      id: 'r1',
+      businessName: 'Sushirrito',
+      businessImage: 'https://picsum.photos/id/292/100/100',
+      location: 'San Francisco',
+      rating: 5,
+      date: '1d ago',
+      content: 'Loved the crunch and fresh fish.',
+      images: [],
+      helpfulCount: 12,
+      createdAt: '2026-02-10T12:00:00.000Z',
+    };
+    const onViewAllReviews = vi.fn();
+
+    render(<MyHistorySection latestReview={latestReview} onViewAllReviews={onViewAllReviews} />);
+
+    expect(screen.getByText('My History')).toBeInTheDocument();
+    expect(screen.getByText('Sushirrito')).toBeInTheDocument();
+    expect(screen.getByText(/Loved the crunch and fresh fish/i)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /view all reviews/i }));
+    expect(onViewAllReviews).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/features/customer/profile/components/__tests__/PendingReviewMerchants.test.tsx
+++ b/src/features/customer/profile/components/__tests__/PendingReviewMerchants.test.tsx
@@ -1,0 +1,37 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import { describe, expect, it, vi } from 'vitest';
+import { PendingReviewMerchants } from '../PendingReviewMerchants';
+import { PendingReviewMerchant } from '../../types';
+
+describe('PendingReviewMerchants', () => {
+  it('renders Laet Merchant I Visit cards and handles write review action', () => {
+    const merchants: PendingReviewMerchant[] = [
+      {
+        id: 'm1',
+        businessName: 'Sushirrito',
+        businessImage: 'https://picsum.photos/id/292/100/100',
+        lastVisitedAt: 'Yesterday',
+        lastOrderItems: ['Sumo Crunch', 'Lava Nachos'],
+      },
+      {
+        id: 'm2',
+        businessName: 'Philz Coffee',
+        businessImage: 'https://picsum.photos/id/431/100/100',
+        lastVisitedAt: 'Jan 22',
+        lastOrderItems: ['Mint Mojito'],
+      },
+    ];
+    const onWriteReview = vi.fn();
+
+    render(<PendingReviewMerchants merchants={merchants} onWriteReview={onWriteReview} />);
+
+    expect(screen.getByText('Laet Merchant I Visit')).toBeInTheDocument();
+    expect(screen.getByText('Sushirrito')).toBeInTheDocument();
+    expect(screen.getByText('Philz Coffee')).toBeInTheDocument();
+    expect(screen.getAllByRole('button', { name: /write review/i })).toHaveLength(2);
+
+    fireEvent.click(screen.getAllByRole('button', { name: /write review/i })[0]);
+    expect(onWriteReview).toHaveBeenCalledWith(merchants[0]);
+  });
+});

--- a/src/features/customer/profile/components/__tests__/StatsBar.test.tsx
+++ b/src/features/customer/profile/components/__tests__/StatsBar.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import { describe, expect, it } from 'vitest';
+import StatsBar from '../StatsBar';
+
+describe('StatsBar', () => {
+  it('shows REVIEWS and FOLLOWING buttons only', () => {
+    render(
+      <StatsBar
+        stats={{
+          totalReviews: 142,
+          photosUploaded: 856,
+          helpfulVotes: 4205,
+          views: '2.4M',
+          following: 318,
+        }}
+      />
+    );
+
+    expect(screen.getByRole('button', { name: /reviews/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /following/i })).toBeInTheDocument();
+    expect(screen.queryByText(/photos/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/\bviews\b/i)).not.toBeInTheDocument();
+    expect(screen.getByText('142')).toBeInTheDocument();
+    expect(screen.getByText('318')).toBeInTheDocument();
+  });
+});

--- a/src/features/customer/profile/components/index.ts
+++ b/src/features/customer/profile/components/index.ts
@@ -7,6 +7,10 @@ export { default as StatsBar } from './StatsBar';
 export { default as ProfileNavbar } from './ProfileNavbar';
 export { SettingItem } from './SettingItem';
 export { NavCard } from './NavCard';
+export { PendingReviewMerchants } from './PendingReviewMerchants';
+export { MyHistorySection } from './MyHistorySection';
+export { SectionHeading } from './SectionHeading';
+export { AccountSection } from './AccountSection';
 
 // Legacy profile components
 export { MeHeader } from './MeHeader';

--- a/src/features/customer/profile/pages/ProfilePage.tsx
+++ b/src/features/customer/profile/pages/ProfilePage.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useMemo, useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useAuth } from '../../../../contexts/AuthContext';
 import { PATHS } from '../../../../routes/paths';
@@ -6,14 +6,18 @@ import {
   Icons,
   ReviewCard,
   CouponCard,
-  OrderCard,
   StatsBar,
   ProfileNavbar,
-  SettingItem,
-  NavCard
+  SectionHeading,
+  AccountSection,
+  PendingReviewMerchants,
+  MyHistorySection
 } from '../components';
-import { generateCreativeBio } from '../services/profileService';
-import { UserProfile, Review, Coupon, Order } from '../types';
+import {
+  generateCreativeBio,
+  getLatestVisitedMerchantsWithoutReview,
+} from '../services/profileService';
+import { UserProfile, Review, Coupon, PendingReviewMerchant } from '../types';
 import { reviewsApi, ReviewResponse } from '../../../../api/reviews';
 
 // Helper function to format date as relative time
@@ -84,27 +88,6 @@ const MOCK_COUPONS: Coupon[] = [
   }
 ];
 
-const MOCK_ORDERS: Order[] = [
-  {
-    id: 'o1',
-    businessName: 'Sushirrito',
-    businessImage: 'https://picsum.photos/id/292/100/100',
-    date: 'Yesterday',
-    items: ['Sumo Crunch', 'Lava Nachos'],
-    total: '$18.50',
-    status: 'completed'
-  },
-  {
-    id: 'o2',
-    businessName: 'Philz Coffee',
-    businessImage: 'https://picsum.photos/id/431/100/100',
-    date: 'Oct 24',
-    items: ['Mint Mojito', 'Avocado Toast'],
-    total: '$12.00',
-    status: 'completed'
-  }
-];
-
 const ProfilePage: React.FC = () => {
   const navigate = useNavigate();
   const { user: authUser, logout } = useAuth();
@@ -113,6 +96,8 @@ const ProfilePage: React.FC = () => {
   const [reviews, setReviews] = useState<Review[]>([]);
   const [reviewsLoading, setReviewsLoading] = useState(false);
   const [reviewsError, setReviewsError] = useState<string | null>(null);
+  const [pendingReviewMerchants, setPendingReviewMerchants] = useState<PendingReviewMerchant[]>([]);
+  const [pendingMerchantsLoading, setPendingMerchantsLoading] = useState(false);
 
   // Fetch reviews from API
   useEffect(() => {
@@ -134,6 +119,23 @@ const ProfilePage: React.FC = () => {
     fetchReviews();
   }, []);
 
+  useEffect(() => {
+    const fetchPendingReviewMerchants = async () => {
+      setPendingMerchantsLoading(true);
+      try {
+        const merchants = await getLatestVisitedMerchantsWithoutReview();
+        setPendingReviewMerchants(merchants);
+      } catch (err) {
+        console.error('Error fetching pending review merchants:', err);
+        setPendingReviewMerchants([]);
+      } finally {
+        setPendingMerchantsLoading(false);
+      }
+    };
+
+    fetchPendingReviewMerchants();
+  }, []);
+
   // Create UserProfile from AuthContext user data
   const [user, setUser] = useState<UserProfile>({
     name: authUser?.name || 'User',
@@ -150,7 +152,8 @@ const ProfilePage: React.FC = () => {
       totalReviews: 142, // TODO: Get from API
       photosUploaded: 856, // TODO: Get from API
       helpfulVotes: 4205, // TODO: Get from API
-      views: '2.4M' // TODO: Get from API
+      views: '2.4M', // TODO: Get from API
+      following: 318, // TODO: Get from API
     }
   });
 
@@ -168,7 +171,29 @@ const ProfilePage: React.FC = () => {
     }
   };
 
+  const handleWriteReviewFromMerchant = (merchant: PendingReviewMerchant) => {
+    navigate(PATHS.CUSTOMER.WRITE_REVIEW, {
+      state: {
+        merchantId: merchant.id,
+        merchantName: merchant.businessName,
+      },
+    });
+  };
+
+  const handleStorageClick = () => {
+    // Placeholder entry reserved for future storage feature.
+  };
+
   const activeCoupons = MOCK_COUPONS.filter(c => c.status === 'active');
+  const latestReview = useMemo(() => {
+    if (reviews.length === 0) {
+      return null;
+    }
+
+    return [...reviews].sort(
+      (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
+    )[0];
+  }, [reviews]);
 
   // --- REVIEWS PAGE VIEW ---
   if (currentView === 'reviews') {
@@ -301,21 +326,15 @@ const ProfilePage: React.FC = () => {
 
                 <StatsBar stats={user.stats} />
 
-                {/* Desktop Settings Menu */}
+                {/* Desktop Account Menu */}
                 <div className="hidden lg:block mt-8">
-                  <h3 className="text-xs font-bold text-gray-400 uppercase tracking-wider mb-3 ml-2">Preferences</h3>
-                  <div className="bg-white border border-gray-100 rounded-2xl overflow-hidden shadow-sm">
-                    <div onClick={() => navigate(PATHS.CUSTOMER.ME.NOTIFICATIONS)}>
-                      <SettingItem icon={<Icons.Bell />} label="Notifications" badge="2" />
-                    </div>
-                    <div onClick={() => navigate(PATHS.CUSTOMER.ME.PRIVACY)}>
-                      <SettingItem icon={<Icons.Shield />} label="Privacy & Security" />
-                    </div>
-                    <div className="h-[1px] bg-gray-100 mx-5 my-1"></div>
-                    <div onClick={handleLogout}>
-                      <SettingItem icon={<Icons.LogOut />} label="Sign Out" isDestructive />
-                    </div>
-                  </div>
+                  <AccountSection
+                    onAccountSecurity={() => navigate(PATHS.CUSTOMER.ME.PRIVACY)}
+                    onNotification={() => navigate(PATHS.CUSTOMER.ME.NOTIFICATIONS)}
+                    onStorage={handleStorageClick}
+                    onSupport={() => navigate(PATHS.CUSTOMER.ME.HELP)}
+                    onLogout={handleLogout}
+                  />
                 </div>
               </div>
             </div>
@@ -324,44 +343,23 @@ const ProfilePage: React.FC = () => {
           {/* --- Right Column: Content Feed --- */}
           <div className="lg:col-span-8 xl:col-span-9 space-y-10 px-4 md:px-0 py-6 md:py-0 pb-20">
 
-            {/* 1. Share & Orders Section */}
-            <section className="animate-fade-in-up" style={{ animationDelay: '0.1s' }}>
-              <div className="flex items-center justify-between mb-5">
-                <h2 className="text-xl font-bold text-gray-900 tracking-tight">Activity</h2>
-              </div>
-              <div className="grid grid-cols-1 lg:grid-cols-2 gap-5">
-                {/* Featured Card */}
-                <div className="rounded-[24px] p-7 text-white shadow-[0_12px_30px_-8px_rgba(153,0,0,0.3)] relative overflow-hidden flex flex-col justify-between min-h-[180px] group cursor-pointer transition-all hover:-translate-y-1 hover:shadow-[0_20px_40px_-10px_rgba(153,0,0,0.4)]">
-                  <div className="absolute inset-0 bg-[#990000]"></div>
-                  <div className="absolute top-0 right-0 w-[300px] h-[300px] bg-[#FFCC00] rounded-full blur-[80px] opacity-40 -translate-y-1/2 translate-x-1/3"></div>
-                  <div className="absolute bottom-0 left-0 w-[200px] h-[200px] bg-purple-900 rounded-full blur-[60px] opacity-30 translate-y-1/2 -translate-x-1/3"></div>
-
-                  <div className="relative z-10">
-                    <div className="flex items-center gap-2 mb-3">
-                      <span className="bg-white/20 backdrop-blur-md border border-white/10 px-2.5 py-0.5 rounded-full text-[11px] font-bold uppercase tracking-wide">Featured Mission</span>
-                    </div>
-                    <h3 className="font-bold text-2xl mb-2 leading-tight">Share your vibe</h3>
-                    <p className="text-white/80 text-sm mb-6 max-w-[85%] font-medium">Rate {MOCK_ORDERS[0].businessName} to unlock the "Taste Maker" badge.</p>
-                    <button className="bg-white text-brand-red px-6 py-2.5 rounded-full text-xs font-bold hover:bg-gray-50 transition-colors shadow-sm active:scale-95 transform">Write Review</button>
-                  </div>
-                  <Icons.MessageSquare className="absolute -bottom-6 -right-6 text-white/10 w-40 h-40 group-hover:scale-110 group-hover:rotate-6 transition-all duration-700" />
-                </div>
-                {/* Latest Order */}
-                <OrderCard order={MOCK_ORDERS[0]} />
-              </div>
-            </section>
+            <PendingReviewMerchants
+              merchants={pendingReviewMerchants}
+              loading={pendingMerchantsLoading}
+              onWriteReview={handleWriteReviewFromMerchant}
+            />
 
             {/* 2. Wallet Section */}
             <section className="animate-fade-in-up" style={{ animationDelay: '0.2s' }}>
-              <div className="flex items-center justify-between mb-5">
-                <div className="flex items-center gap-3">
-                  <div className="bg-gradient-to-br from-gray-900 to-black text-white p-2 rounded-xl shadow-md">
-                    <Icons.Wallet size={18} className="fill-current" />
-                  </div>
-                  <h2 className="text-xl font-bold text-gray-900 tracking-tight">My Rewards</h2>
-                </div>
-                <span className="text-xs font-bold text-brand-red bg-brand-red/5 px-3 py-1.5 rounded-full border border-brand-red/10">{activeCoupons.length} Available</span>
-              </div>
+              <SectionHeading
+                icon={<Icons.Wallet />}
+                title="My Rewards"
+                rightSlot={(
+                  <span className="text-xs font-bold text-brand-red bg-brand-red/5 px-3 py-1.5 rounded-full border border-brand-red/10">
+                    {activeCoupons.length} Available
+                  </span>
+                )}
+              />
 
               <div className="flex overflow-x-auto gap-5 pb-6 -mx-4 px-4 scrollbar-hide snap-x snap-mandatory md:grid md:grid-cols-2 xl:grid-cols-3 md:overflow-visible md:pb-0 md:mx-0 md:px-0">
                 {activeCoupons.map((coupon) => (
@@ -378,44 +376,21 @@ const ProfilePage: React.FC = () => {
               </div>
             </section>
 
-            {/* 3. My Content Grid */}
-            <section className="animate-fade-in-up" style={{ animationDelay: '0.3s' }}>
-              <h2 className="text-xl font-bold text-gray-900 tracking-tight mb-5">Contributions</h2>
-
-              <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-2 gap-5">
-                {/* REVIEWS BOX */}
-                <NavCard
-                  icon={<Icons.Review />}
-                  title="My Reviews"
-                  subtitle={`${user.stats.totalReviews} posted • 80k views`}
-                  onClick={() => setCurrentView('reviews')}
-                />
-
-                {/* PHOTOS BOX */}
-                <NavCard
-                  icon={<Icons.Camera />}
-                  title="Photos"
-                  subtitle={`${user.stats.photosUploaded} uploaded • 2.1M views`}
-                  colorClass="text-brand-darkGold"
-                  onClick={() => {}} // TODO: Implement photos view
-                />
-              </div>
-            </section>
+            <MyHistorySection
+              latestReview={latestReview}
+              loading={reviewsLoading}
+              onViewAllReviews={() => setCurrentView('reviews')}
+            />
 
             {/* Mobile Settings */}
             <section className="lg:hidden mt-8 mb-12">
-              <h3 className="text-xs font-bold text-gray-400 uppercase tracking-wider mb-3 px-1">Account</h3>
-              <div className="bg-white rounded-2xl overflow-hidden shadow-sm border border-gray-100">
-                <div onClick={() => navigate(PATHS.CUSTOMER.ME.NOTIFICATIONS)}>
-                  <SettingItem icon={<Icons.Bell />} label="Notifications" badge="2" />
-                </div>
-                <div onClick={() => navigate(PATHS.CUSTOMER.ME.PRIVACY)}>
-                  <SettingItem icon={<Icons.Shield />} label="Security" />
-                </div>
-                <div onClick={handleLogout}>
-                  <SettingItem icon={<Icons.LogOut />} label="Log Out" isDestructive />
-                </div>
-              </div>
+              <AccountSection
+                onAccountSecurity={() => navigate(PATHS.CUSTOMER.ME.PRIVACY)}
+                onNotification={() => navigate(PATHS.CUSTOMER.ME.NOTIFICATIONS)}
+                onStorage={handleStorageClick}
+                onSupport={() => navigate(PATHS.CUSTOMER.ME.HELP)}
+                onLogout={handleLogout}
+              />
             </section>
 
           </div>

--- a/src/features/customer/profile/services/profileService.ts
+++ b/src/features/customer/profile/services/profileService.ts
@@ -1,8 +1,32 @@
 import { GoogleGenerativeAI } from "@google/generative-ai";
-import { UserProfile } from '../types';
+import { PendingReviewMerchant, UserProfile } from '../types';
 
 // TODO: Move API key to environment variable for security
 const genAI = new GoogleGenerativeAI('AIzaSyDCInZ57xrv6hpYu-oGqPfm0wa8zEHYYBM');
+
+const MOCK_PENDING_REVIEW_MERCHANTS: PendingReviewMerchant[] = [
+  {
+    id: 'm1',
+    businessName: 'Sushirrito',
+    businessImage: 'https://picsum.photos/id/292/100/100',
+    lastVisitedAt: 'Yesterday',
+    lastOrderItems: ['Sumo Crunch', 'Lava Nachos'],
+  },
+  {
+    id: 'm2',
+    businessName: 'Philz Coffee',
+    businessImage: 'https://picsum.photos/id/431/100/100',
+    lastVisitedAt: 'Jan 22',
+    lastOrderItems: ['Mint Mojito', 'Avocado Toast'],
+  },
+  {
+    id: 'm3',
+    businessName: 'Urban Ritual',
+    businessImage: 'https://picsum.photos/id/63/100/100',
+    lastVisitedAt: 'Jan 19',
+    lastOrderItems: ['Dirty Horchata', 'Classic Milk Tea'],
+  },
+];
 
 /**
  * Generates a creative bio for the user using Google's Gemini AI
@@ -48,4 +72,21 @@ Return ONLY the bio text.`;
     // Fallback to original bio on error
     return user.bio;
   }
+};
+
+async function fetchPendingReviewMerchantsFromApi(): Promise<PendingReviewMerchant[]> {
+  // API entry reserved for backend integration.
+  // TODO: replace with real endpoint call, e.g.
+  // const response = await apiClient.get<PendingReviewMerchant[]>('/user/merchants/pending-reviews');
+  // return response.data;
+  return [];
+}
+
+export const getLatestVisitedMerchantsWithoutReview = async (): Promise<PendingReviewMerchant[]> => {
+  const apiMerchants = await fetchPendingReviewMerchantsFromApi();
+  if (apiMerchants.length > 0) {
+    return apiMerchants;
+  }
+
+  return MOCK_PENDING_REVIEW_MERCHANTS;
 };

--- a/src/features/customer/profile/types/index.ts
+++ b/src/features/customer/profile/types/index.ts
@@ -18,6 +18,7 @@ export interface UserStats {
   photosUploaded: number;
   helpfulVotes: number;
   views: string;
+  following: number;
 }
 
 // Review Types
@@ -55,4 +56,12 @@ export interface Order {
   items: string[];
   total: string;
   status: 'completed' | 'pending' | 'cancelled';
+}
+
+export interface PendingReviewMerchant {
+  id: string;
+  businessName: string;
+  businessImage: string;
+  lastVisitedAt: string;
+  lastOrderItems: string[];
 }


### PR DESCRIPTION
Refined the customer profile page structure and section hierarchy.

- Replaced stats actions with REVIEWS/FOLLOWING buttons.
- Added pending-review merchant cards and API placeholder entry.
- Added My History section with latest review quick access.
- Unified subsection headings with icon-first title styling.
- Updated Account entries and kept requested waitting text.

Refs: #132