### PR TITLE
fix(reviews): align post review flow with backend contract (#139)

### DIFF
--- a/src/api/__tests__/reviews.test.ts
+++ b/src/api/__tests__/reviews.test.ts
@@ -1,0 +1,90 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+const { mockGet, mockPost } = vi.hoisted(() => ({
+  mockGet: vi.fn(),
+  mockPost: vi.fn(),
+}));
+
+vi.mock('../apiClient', () => ({
+  apiClient: {
+    get: mockGet,
+    post: mockPost,
+  },
+}));
+
+import { reviewsApi } from '../reviews';
+
+const backendReview = {
+  id: '99',
+  merchantId: '12',
+  venueId: '12',
+  storeId: '34',
+  userId: '7',
+  rating: 4.5,
+  text: 'Excellent noodles',
+  images: ['https://cdn.revieu.com/reviews/noodles.jpg'],
+  tags: ['#noodles'],
+  visitDate: '2026-03-07',
+  createdAt: '2026-03-07T10:00:00Z',
+  businessName: 'Northern Cafe',
+  businessImage: 'https://cdn.revieu.com/merchant.jpg',
+  location: '123 Main St',
+  likeCount: 8,
+};
+
+describe('reviewsApi', () => {
+  beforeEach(() => {
+    mockGet.mockReset();
+    mockPost.mockReset();
+  });
+
+  test('create sends backend review payload and maps response back to frontend fields', async () => {
+    mockPost.mockResolvedValue({ data: backendReview });
+
+    const response = await reviewsApi.create({
+      merchantId: '12',
+      storeId: '34',
+      overallRating: 4.5,
+      text: 'Excellent noodles',
+      images: ['https://cdn.revieu.com/reviews/noodles.jpg'],
+      tags: ['#noodles'],
+      visitDate: '2026-03-07',
+    });
+
+    expect(mockPost).toHaveBeenCalledWith('/reviews', {
+      merchantId: '12',
+      storeId: '34',
+      rating: 4.5,
+      text: 'Excellent noodles',
+      images: ['https://cdn.revieu.com/reviews/noodles.jpg'],
+      tags: ['#noodles'],
+      visitDate: '2026-03-07',
+    });
+    expect(response).toMatchObject({
+      id: '99',
+      merchantId: '12',
+      storeId: '34',
+      overallRating: 4.5,
+      text: 'Excellent noodles',
+      businessName: 'Northern Cafe',
+    });
+  });
+
+  test('list maps backend rating fields for frontend consumers', async () => {
+    mockGet.mockResolvedValue({
+      data: {
+        data: [backendReview],
+      },
+    });
+
+    const response = await reviewsApi.list();
+
+    expect(mockGet).toHaveBeenCalledWith('/reviews');
+    expect(response.data).toHaveLength(1);
+    expect(response.data[0]).toMatchObject({
+      id: '99',
+      overallRating: 4.5,
+      businessName: 'Northern Cafe',
+    });
+  });
+});

--- a/src/api/reviews.ts
+++ b/src/api/reviews.ts
@@ -3,7 +3,8 @@ import { apiClient } from './apiClient';
 // Request types
 export interface CreateReviewRequest {
     merchantId: string;
-    venueId: string;
+    storeId?: string;
+    venueId?: string;
     overallRating: number;
     detailedRatings?: {
         quality: number;
@@ -21,6 +22,8 @@ export interface CreateReviewRequest {
 export interface ReviewResponse {
     id: string;
     merchantId: string;
+    venueId?: string;
+    storeId?: string;
     userId: string;
     overallRating: number;
     detailedRatings?: {
@@ -31,6 +34,7 @@ export interface ReviewResponse {
     text?: string;
     images: string[];
     tags: string[];
+    visitDate?: string;
     createdAt: string;
     status?: string;
     businessName: string;
@@ -43,6 +47,50 @@ export interface ReviewListResponse {
     data: ReviewResponse[];
 }
 
+interface BackendReviewResponse {
+    id: string;
+    merchantId: string;
+    venueId?: string;
+    storeId?: string;
+    userId: string;
+    rating: number;
+    text?: string;
+    images?: string[];
+    tags?: string[];
+    visitDate?: string;
+    createdAt: string;
+    status?: string;
+    businessName: string;
+    businessImage: string;
+    location: string;
+    likeCount: number;
+}
+
+interface BackendReviewListResponse {
+    data: BackendReviewResponse[];
+}
+
+function mapReviewResponse(review: BackendReviewResponse): ReviewResponse {
+    return {
+        id: review.id,
+        merchantId: review.merchantId,
+        venueId: review.venueId,
+        storeId: review.storeId,
+        userId: review.userId,
+        overallRating: review.rating,
+        text: review.text,
+        images: review.images ?? [],
+        tags: review.tags ?? [],
+        visitDate: review.visitDate,
+        createdAt: review.createdAt,
+        status: review.status,
+        businessName: review.businessName,
+        businessImage: review.businessImage,
+        location: review.location,
+        likeCount: review.likeCount,
+    };
+}
+
 /**
  * Reviews API service
  */
@@ -51,34 +99,35 @@ export const reviewsApi = {
      * Create a new review
      */
     create: async (request: CreateReviewRequest): Promise<ReviewResponse> => {
-        // Transform to backend format (rating instead of overallRating)
         const backendRequest = {
             merchantId: request.merchantId,
-            venueId: request.venueId,
+            storeId: request.storeId ?? request.venueId,
             rating: request.overallRating,
             text: request.text,
             images: request.images,
             tags: request.tags,
             visitDate: request.visitDate,
         };
-        const response = await apiClient.post<ReviewResponse>('/reviews', backendRequest);
-        return response.data;
+        const response = await apiClient.post<BackendReviewResponse>('/reviews', backendRequest);
+        return mapReviewResponse(response.data);
     },
 
     /**
      * Get user's reviews
      */
     list: async (): Promise<ReviewListResponse> => {
-        const response = await apiClient.get<ReviewListResponse>('/reviews');
-        return response.data;
+        const response = await apiClient.get<BackendReviewListResponse>('/reviews');
+        return {
+            data: response.data.data.map(mapReviewResponse),
+        };
     },
 
     /**
      * Get review by ID
      */
     getById: async (id: string): Promise<ReviewResponse> => {
-        const response = await apiClient.get<ReviewResponse>(`/reviews/${id}`);
-        return response.data;
+        const response = await apiClient.get<BackendReviewResponse>(`/reviews/${id}`);
+        return mapReviewResponse(response.data);
     },
 
     /**

--- a/src/features/customer/pages/MerchantDetailPage/RestaurantDetailPage.tsx
+++ b/src/features/customer/pages/MerchantDetailPage/RestaurantDetailPage.tsx
@@ -1,24 +1,33 @@
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 import { RestaurantDetail } from './components/RestaurantDetail';
 import { PATHS } from '../../../../routes/paths';
 
 const RestaurantDetailPage: React.FC = () => {
   const navigate = useNavigate();
+  const { id } = useParams<{ id: string }>();
 
   const handleBack = () => {
     navigate(PATHS.CUSTOMER.DISCOVER);
   };
 
   const handleViewAllReviews = () => {
-    // Navigate to reviews page using existing MERCHANT_INFO pattern
-    const merchantId = '1'; // 这里应该从URL参数或props中获取实际的商户ID
+    const merchantId = id ?? '1';
     navigate(`/customer/merchant/${merchantId}/reviews`);
+  };
+
+  const handleWriteReview = () => {
+    navigate(PATHS.CUSTOMER.WRITE_REVIEW, {
+      state: {
+        merchantId: id,
+      },
+    });
   };
 
   return (
     <RestaurantDetail 
       onBack={handleBack}
       onViewAllReviews={handleViewAllReviews}
+      onWriteReview={handleWriteReview}
     />
   );
 };

--- a/src/features/customer/pages/MerchantDetailPage/components/RestaurantDetail.tsx
+++ b/src/features/customer/pages/MerchantDetailPage/components/RestaurantDetail.tsx
@@ -12,9 +12,10 @@ import { MenuUploadWidget } from './MenuUploadWidget';
 interface RestaurantDetailProps {
   onBack?: () => void;
   onViewAllReviews?: () => void;
+  onWriteReview?: () => void;
 }
 
-export function RestaurantDetail({ onBack, onViewAllReviews }: RestaurantDetailProps) {
+export function RestaurantDetail({ onBack, onViewAllReviews, onWriteReview }: RestaurantDetailProps) {
   const [activeTab, setActiveTab] = useState<'deals' | 'menu' | 'reviews'>('deals');
 
   return (
@@ -318,7 +319,7 @@ export function RestaurantDetail({ onBack, onViewAllReviews }: RestaurantDetailP
       </div>
 
       {/* Glossy Bottom Navigation */}
-      <GlossyBottomNav onBack={onBack} />
+      <GlossyBottomNav onBack={onBack} onWriteReview={onWriteReview} />
     </div>
   );
 }

--- a/src/features/customer/reviews/contexts/ReviewContext.tsx
+++ b/src/features/customer/reviews/contexts/ReviewContext.tsx
@@ -622,6 +622,7 @@ const ReviewContext = createContext<{
 interface ReviewProviderProps {
   children: ReactNode;
   merchantId?: string;
+  storeId?: string;
   venueId?: string;
   merchantName?: string;
   merchantCategory?: BusinessCategory;
@@ -630,6 +631,7 @@ interface ReviewProviderProps {
 export const ReviewProvider: React.FC<ReviewProviderProps> = ({
   children,
   merchantId,
+  storeId,
   venueId,
 }) => {
   const [state, dispatch] = useReducer(reviewReducer, {
@@ -637,6 +639,7 @@ export const ReviewProvider: React.FC<ReviewProviderProps> = ({
     reviewData: {
       ...initialState.reviewData,
       merchantId,
+      storeId,
       venueId,
     },
   });
@@ -955,7 +958,7 @@ export const ReviewProvider: React.FC<ReviewProviderProps> = ({
 
         const request: CreateReviewRequest = {
           merchantId: state.reviewData.merchantId || '',
-          venueId: state.reviewData.venueId || '',
+          storeId: state.reviewData.storeId || state.reviewData.venueId || undefined,
           overallRating: state.reviewData.overallRating || 0,
           detailedRatings: state.reviewData.detailedRatings,
           text: state.reviewData.reviewText,

--- a/src/features/customer/reviews/pages/WriteReviewPage.tsx
+++ b/src/features/customer/reviews/pages/WriteReviewPage.tsx
@@ -1,11 +1,19 @@
 import React, { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { Camera, Hash, X, Plus } from 'lucide-react';
 import { useReviewContext } from '../contexts/ReviewContext';
 import { ReviewProvider } from '../contexts/ReviewContext';
 import { CombinedRatingComponent, ImageUploadGrid, AIAssistantButton, AISuggestionsList } from '../components';
 import { BusinessCategory } from '../types';
 import { PATHS } from '../../../../routes/paths';
+
+interface WriteReviewLocationState {
+  merchantId?: string;
+  merchantName?: string;
+  storeId?: string;
+  venueId?: string;
+  merchantCategory?: BusinessCategory;
+}
 
 // Internal component that uses the review context
 const WriteReviewForm: React.FC = () => {
@@ -419,13 +427,16 @@ const WriteReviewForm: React.FC = () => {
 };
 
 const WriteReviewPage: React.FC = () => {
-  // TODO: Get merchantId and venueId from route params or props
+  const location = useLocation();
+  const reviewContext = (location.state as WriteReviewLocationState | null) ?? null;
+
   return (
     <ReviewProvider
-      merchantId="1"
-      venueId="1"
-      merchantName="Sample Restaurant"
-      merchantCategory={BusinessCategory.RESTAURANT}
+      merchantId={reviewContext?.merchantId}
+      storeId={reviewContext?.storeId}
+      venueId={reviewContext?.venueId}
+      merchantName={reviewContext?.merchantName}
+      merchantCategory={reviewContext?.merchantCategory ?? BusinessCategory.RESTAURANT}
     >
       <WriteReviewForm />
     </ReviewProvider>

--- a/src/features/customer/reviews/pages/__tests__/WriteReviewPage.test.tsx
+++ b/src/features/customer/reviews/pages/__tests__/WriteReviewPage.test.tsx
@@ -1,7 +1,12 @@
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom/vitest';
 import { vi, test, expect } from 'vitest';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { PATHS } from '../../../../../routes/paths';
+
+const { reviewProviderSpy } = vi.hoisted(() => ({
+  reviewProviderSpy: vi.fn(({ children }: { children: React.ReactNode }) => <div>{children}</div>),
+}));
 
 vi.mock('../../contexts/ReviewContext', () => ({
   useReviewContext: () => ({
@@ -33,10 +38,11 @@ vi.mock('../../contexts/ReviewContext', () => ({
       clearDraftNotice: vi.fn(),
     },
   }),
-  ReviewProvider: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  ReviewProvider: reviewProviderSpy,
 }));
 
 test('renders upload, submit, and draft banners', async () => {
+  reviewProviderSpy.mockClear();
   const { default: WriteReviewPage } = await import('../WriteReviewPage');
   render(
     <MemoryRouter>
@@ -46,4 +52,37 @@ test('renders upload, submit, and draft banners', async () => {
   expect(screen.getByText(/upload failed/i)).toBeInTheDocument();
   expect(screen.getByText(/submit failed/i)).toBeInTheDocument();
   expect(screen.getByText(/draft restored/i)).toBeInTheDocument();
+});
+
+test('passes merchant context from router state into ReviewProvider', async () => {
+  reviewProviderSpy.mockClear();
+  const { default: WriteReviewPage } = await import('../WriteReviewPage');
+
+  render(
+    <MemoryRouter
+      initialEntries={[
+        {
+          pathname: PATHS.CUSTOMER.WRITE_REVIEW,
+          state: {
+            merchantId: '42',
+            merchantName: 'Golden Spoon',
+            storeId: '108',
+          },
+        },
+      ]}
+    >
+      <Routes>
+        <Route path={PATHS.CUSTOMER.WRITE_REVIEW} element={<WriteReviewPage />} />
+      </Routes>
+    </MemoryRouter>
+  );
+
+  expect(reviewProviderSpy).toHaveBeenCalledWith(
+    expect.objectContaining({
+      merchantId: '42',
+      merchantName: 'Golden Spoon',
+      storeId: '108',
+    }),
+    expect.anything()
+  );
 });

--- a/src/features/customer/reviews/types/index.ts
+++ b/src/features/customer/reviews/types/index.ts
@@ -76,6 +76,7 @@ export interface CombinedRatingProps {
 export interface ReviewData {
   id: string;
   merchantId: string;
+  storeId?: string;
   venueId: string;
   userId: string;
   overallRating: number;


### PR DESCRIPTION
## Summary
- align the review API client with the backend create/list/detail contract by sending `storeId` and mapping backend `rating` to frontend `overallRating`
- pass merchant review context through navigation state so Write Review no longer relies on hardcoded merchant identifiers
- add regression coverage for the API field mapping and Write Review route-state wiring

## Test Plan
- [x] `npm run test:run -- src/api/__tests__/reviews.test.ts src/features/customer/reviews/pages/__tests__/WriteReviewPage.test.tsx`
- [x] `npm run test`
- [x] `npm run build`

Closes #139