### PR TITLE
fix(home): restore #142 header layout on homepage

### DIFF
--- a/docs/plans/2026-03-08-homepage-142-restoration.md
+++ b/docs/plans/2026-03-08-homepage-142-restoration.md
@@ -1,0 +1,68 @@
+# Homepage 142 Restoration Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Restore the homepage presentation from PR `#142` while preserving the newer search-entry and merchant-navigation behavior added after it.
+
+**Architecture:** Keep `HomePage.tsx` and `MerchantFeed.tsx` on the current `dev` behavior because their diffs versus `#142` are functional, not visual. Restore only the `Header.tsx` search-bar markup and styling to the `#142` layout, while retaining the `onSearchTap` callback wiring.
+
+**Tech Stack:** React 18, TypeScript, Vitest, Testing Library, Vite
+
+---
+
+### Task 1: Lock the intended header behavior with a regression test
+
+**Files:**
+- Create: `src/features/customer/home/components/__tests__/Header.test.tsx`
+- Modify: `src/features/customer/home/components/Header.tsx`
+
+**Step 1: Write the failing test**
+
+Add a test that renders `Header` with `onSearchTap` and asserts:
+- the search input is present
+- pressing on the input calls `onSearchTap`
+- the header exposes only the notification button and the main mic/search action button (no extra inline action button inside the input row)
+
+**Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/features/customer/home/components/__tests__/Header.test.tsx`
+Expected: FAIL because the current header renders one extra button inside the search field.
+
+### Task 2: Restore the #142 header layout without dropping navigation behavior
+
+**Files:**
+- Modify: `src/features/customer/home/components/Header.tsx`
+
+**Step 1: Apply the minimal implementation**
+
+Update `Header.tsx` so that:
+- the search row matches the `#142` layout
+- the input keeps `readOnly`, `onMouseDown`, and `onKeyDown` behavior when `onSearchTap` is provided
+- the extra inline action button inside the input container is removed
+- the outer mic CTA remains
+
+**Step 2: Run the targeted test**
+
+Run: `npx vitest run src/features/customer/home/components/__tests__/Header.test.tsx`
+Expected: PASS
+
+### Task 3: Verify the restoration did not break the branch
+
+**Files:**
+- Confirm unchanged: `src/features/customer/home/pages/HomePage.tsx`
+- Confirm unchanged: `src/features/customer/home/components/MerchantFeed.tsx`
+
+**Step 1: Run typecheck**
+
+Run: `npx tsc --noEmit`
+Expected: PASS
+
+**Step 2: Run the full test suite used by CI**
+
+Run: `npm run test:run`
+Expected: PASS
+
+**Step 3: Review diff**
+
+Run: `git diff --stat`
+Expected: only the new header test and the header restoration change are present.

--- a/src/features/customer/home/components/Header.tsx
+++ b/src/features/customer/home/components/Header.tsx
@@ -49,45 +49,36 @@ const Header: React.FC<HeaderProps> = ({ onSearch = () => { }, onSearchTap }) =>
                         isFocused ? 'bg-white border-[#990000]/30 shadow-lg shadow-[#990000]/5' : 'border-transparent'
                     }`}>
                         <div className="pl-3 pr-2">
-                            <img src={searchIcon} className=''/>
+                            <img src={searchIcon} className="" />
                         </div>
 
-                    <input
-                        type="text"
-                        onFocus={() => setIsFocused(true)}
-                        onBlur={() => setIsFocused(false)}
-                        placeholder="Search USC..."
-                        readOnly={Boolean(onSearchTap)}
-                        onMouseDown={(e) => {
-                            if (!onSearchTap) {
-                                return;
-                            }
+                        <input
+                            type="text"
+                            onFocus={() => setIsFocused(true)}
+                            onBlur={() => setIsFocused(false)}
+                            placeholder="Search"
+                            readOnly={Boolean(onSearchTap)}
+                            onMouseDown={(e) => {
+                                if (!onSearchTap) {
+                                    return;
+                                }
 
-                            e.preventDefault();
-                            onSearchTap();
-                        }}
-                        onKeyDown={(e) => {
-                            if (!onSearchTap) {
-                                return;
-                            }
-
-                            if (e.key === 'Enter' || e.key === ' ') {
                                 e.preventDefault();
                                 onSearchTap();
-                            }
-                        }}
-                        onChange={(e) => onSearch(e.target.value)}
-                        className="flex-1 bg-transparent border-none py-2.5 text-[14px] font-semibold text-gray-900 outline-none placeholder:text-gray-400"
-                    />
+                            }}
+                            onKeyDown={(e) => {
+                                if (!onSearchTap) {
+                                    return;
+                                }
 
-                    <div className="pr-2 flex items-center space-x-2">
-                        <div className="w-[1px] h-3 bg-gray-300" />
-                        <button className="text-[#990000] p-1">
-                            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2.5" d="M19 11a7 7 0 01-7 7m0 0a7 7 0 01-7-7m7 7v4m0 0H8m4 0h4m-4-8a3 3 0 01-3-3V5a3 3 0 116 0v6a3 3 0 01-3 3z" />
-                            </svg>
-                        </button>
-                    </div>
+                                if (e.key === 'Enter' || e.key === ' ') {
+                                    e.preventDefault();
+                                    onSearchTap();
+                                }
+                            }}
+                            onChange={(e) => onSearch(e.target.value)}
+                            className="h-full flex-1 bg-transparent border-none py-0 text-[14px] font-semibold text-gray-900 outline-none placeholder:text-gray-400"
+                        />
                     </div>
                     <button className="w-[50px] h-[50px] shrink-0 rounded-[18px] bg-[linear-gradient(48.58deg,_#990000_6.33%,_#CB3232_96.68%)] text-white flex items-center justify-center">
                         <img src={micIcon} className="w-[25px] h-[25px]">

--- a/src/features/customer/home/components/__tests__/Header.test.tsx
+++ b/src/features/customer/home/components/__tests__/Header.test.tsx
@@ -1,0 +1,30 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import { describe, expect, it, vi } from 'vitest';
+import Header from '../Header';
+
+vi.mock('../../../../../contexts/AuthContext', () => ({
+  useAuth: () => ({
+    user: {
+      id: '1',
+      email: 'tester@example.com',
+      name: 'Tester',
+      role: 'user',
+    },
+  }),
+}));
+
+describe('Header', () => {
+  it('keeps search tap navigation while rendering only the primary search action button', () => {
+    const onSearchTap = vi.fn();
+
+    render(<Header onSearchTap={onSearchTap} />);
+
+    const input = screen.getByRole('textbox');
+
+    fireEvent.mouseDown(input);
+
+    expect(onSearchTap).toHaveBeenCalledTimes(1);
+    expect(screen.getAllByRole('button')).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
## Summary
- restore the homepage header search bar layout from PR #142
- keep the newer search tap navigation behavior added after #142
- add a regression test covering the restored header interaction

## Test Plan
- npx tsc --noEmit
- npm run test:run