### PR TITLE
feat(review): add merchant search step to write review flow

### DIFF
--- a/src/api/merchants.ts
+++ b/src/api/merchants.ts
@@ -1,0 +1,32 @@
+import { apiClient } from './apiClient';
+
+export interface MerchantListItem {
+    id: string;
+    name: string;
+    businessName: string;
+    category: string;
+    rating: number;
+    reviewCount: number;
+    coverImage: string;
+}
+
+interface MerchantListParams {
+    search?: string;
+    category?: string;
+}
+
+interface BackendMerchantListResponse {
+    data: MerchantListItem[];
+}
+
+export const merchantsApi = {
+    list: async (params: MerchantListParams = {}): Promise<MerchantListItem[]> => {
+        const response = await apiClient.get<BackendMerchantListResponse>('/merchants', { params });
+        return response.data.data;
+    },
+
+    getById: async (id: string): Promise<MerchantListItem> => {
+        const response = await apiClient.get<MerchantListItem>(`/merchants/${id}`);
+        return response.data;
+    },
+};

--- a/src/features/customer/reviews/components/MerchantSearchStep.tsx
+++ b/src/features/customer/reviews/components/MerchantSearchStep.tsx
@@ -1,0 +1,135 @@
+import React, { useState, useEffect, useRef, useCallback } from 'react';
+import { Search, Star, ChevronLeft } from 'lucide-react';
+import { merchantsApi, MerchantListItem } from '../../../../api/merchants';
+
+interface MerchantSearchStepProps {
+  onSelect: (merchant: { id: string; name: string; category: string }) => void;
+  onBack?: () => void;
+}
+
+const DEBOUNCE_MS = 300;
+
+const MerchantSearchStep: React.FC<MerchantSearchStepProps> = ({ onSelect, onBack }) => {
+  const [query, setQuery] = useState('');
+  const [merchants, setMerchants] = useState<MerchantListItem[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [hasSearched, setHasSearched] = useState(false);
+  const timerRef = useRef<number | null>(null);
+
+  const fetchMerchants = useCallback(async (search: string) => {
+    setLoading(true);
+    try {
+      const data = await merchantsApi.list({ search: search || undefined });
+      setMerchants(data);
+    } catch {
+      setMerchants([]);
+    } finally {
+      setLoading(false);
+      setHasSearched(true);
+    }
+  }, []);
+
+  // Load all merchants on mount
+  useEffect(() => {
+    fetchMerchants('');
+  }, [fetchMerchants]);
+
+  // Debounced search
+  useEffect(() => {
+    if (timerRef.current) window.clearTimeout(timerRef.current);
+    timerRef.current = window.setTimeout(() => {
+      fetchMerchants(query.trim());
+    }, DEBOUNCE_MS);
+    return () => {
+      if (timerRef.current) window.clearTimeout(timerRef.current);
+    };
+  }, [query, fetchMerchants]);
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-gray-50 to-gray-100">
+      {/* Header */}
+      <div className="sticky top-0 bg-white/95 backdrop-blur-md border-b border-gray-100 px-4 h-16 flex items-center gap-3 z-20 shadow-sm">
+        {onBack && (
+          <button onClick={onBack} className="p-1.5 rounded-lg hover:bg-gray-100 transition-colors">
+            <ChevronLeft className="w-5 h-5 text-gray-600" />
+          </button>
+        )}
+        <h1 className="font-semibold text-gray-800 text-lg">Select Business</h1>
+      </div>
+
+      <div className="p-4 max-w-2xl mx-auto space-y-4">
+        {/* Search Input */}
+        <div className="relative">
+          <Search className="absolute left-3.5 top-1/2 -translate-y-1/2 w-4.5 h-4.5 text-gray-400" />
+          <input
+            type="text"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="Search by business name..."
+            autoFocus
+            className="w-full pl-10 pr-4 py-3 bg-white border border-gray-200 rounded-xl text-sm focus:outline-none focus:ring-2 focus:ring-[#990000]/20 focus:border-[#990000] transition-all duration-200 shadow-sm"
+          />
+        </div>
+
+        {/* Results */}
+        {loading && !hasSearched ? (
+          <div className="flex justify-center py-12">
+            <div className="w-8 h-8 border-2 border-gray-200 border-t-[#990000] rounded-full animate-spin" />
+          </div>
+        ) : merchants.length === 0 && hasSearched ? (
+          <div className="text-center py-12">
+            <p className="text-gray-400 text-sm">No businesses found</p>
+            {query && <p className="text-gray-300 text-xs mt-1">Try a different search term</p>}
+          </div>
+        ) : (
+          <div className="space-y-2">
+            {merchants.map((m) => (
+              <button
+                key={m.id}
+                onClick={() => onSelect({ id: m.id, name: m.businessName || m.name, category: m.category })}
+                className="w-full flex items-center gap-3.5 bg-white rounded-2xl p-3.5 shadow-sm border border-gray-100/50 hover:border-[#990000]/30 hover:shadow-md transition-all duration-200 text-left active:scale-[0.98]"
+              >
+                {/* Avatar */}
+                <div className="w-12 h-12 rounded-xl bg-gradient-to-br from-gray-100 to-gray-200 flex-shrink-0 overflow-hidden">
+                  {m.coverImage ? (
+                    <img src={m.coverImage} alt="" className="w-full h-full object-cover" />
+                  ) : (
+                    <div className="w-full h-full flex items-center justify-center text-lg font-bold text-gray-400">
+                      {(m.businessName || m.name).charAt(0).toUpperCase()}
+                    </div>
+                  )}
+                </div>
+
+                {/* Info */}
+                <div className="flex-1 min-w-0">
+                  <p className="text-sm font-medium text-gray-800 truncate">
+                    {m.businessName || m.name}
+                  </p>
+                  <div className="flex items-center gap-2 mt-0.5">
+                    {m.category && (
+                      <span className="text-xs text-gray-400 bg-gray-100 px-1.5 py-0.5 rounded-full">{m.category}</span>
+                    )}
+                    {m.rating > 0 && (
+                      <span className="flex items-center gap-0.5 text-xs text-amber-600">
+                        <Star className="w-3 h-3 fill-amber-400 text-amber-400" />
+                        {m.rating.toFixed(1)}
+                      </span>
+                    )}
+                    {m.reviewCount > 0 && (
+                      <span className="text-xs text-gray-400">{m.reviewCount} reviews</span>
+                    )}
+                  </div>
+                </div>
+
+                {/* Arrow */}
+                <ChevronLeft className="w-4 h-4 text-gray-300 rotate-180 flex-shrink-0" />
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default MerchantSearchStep;

--- a/src/features/customer/reviews/components/index.ts
+++ b/src/features/customer/reviews/components/index.ts
@@ -3,5 +3,6 @@ export { default as AISuggestionsList } from './AISuggestionsList';
 export { default as CombinedRatingComponent } from './CombinedRatingComponent';
 export { default as DetailedRatingsComponent } from './DetailedRatingsComponent';
 export { ImageUploadGrid, ImageUploadWrapper } from './ImageUpload';
+export { default as MerchantSearchStep } from './MerchantSearchStep';
 export { default as StarRatingComponent } from './StarRatingComponent';
 export { StudentPost } from './StudentPost';

--- a/src/features/customer/reviews/pages/WriteReviewPage.tsx
+++ b/src/features/customer/reviews/pages/WriteReviewPage.tsx
@@ -1,9 +1,9 @@
 import React, { useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
-import { Camera, Hash, X, Plus } from 'lucide-react';
+import { Camera, Hash, X, Plus, ChevronLeft } from 'lucide-react';
 import { useReviewContext } from '../contexts/ReviewContext';
 import { ReviewProvider } from '../contexts/ReviewContext';
-import { CombinedRatingComponent, ImageUploadGrid, AIAssistantButton, AISuggestionsList } from '../components';
+import { CombinedRatingComponent, ImageUploadGrid, AIAssistantButton, AISuggestionsList, MerchantSearchStep } from '../components';
 import { BusinessCategory } from '../types';
 import { PATHS } from '../../../../routes/paths';
 
@@ -16,7 +16,10 @@ interface WriteReviewLocationState {
 }
 
 // Internal component that uses the review context
-const WriteReviewForm: React.FC = () => {
+const WriteReviewForm: React.FC<{
+  showBackToSearch?: boolean;
+  onBackToSearch?: () => void;
+}> = ({ showBackToSearch, onBackToSearch }) => {
   const navigate = useNavigate();
   const { state, actions } = useReviewContext();
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -124,7 +127,13 @@ const WriteReviewForm: React.FC = () => {
     <div className="min-h-screen bg-gradient-to-br from-gray-50 to-gray-100">
       {/* Header - Center aligned title with symmetric padding */}
       <div className="sticky top-0 bg-white/95 backdrop-blur-md border-b border-gray-100 px-4 h-16 grid grid-cols-3 items-center z-20 shadow-sm">
-        <div /> {/* Spacer for floating back button */}
+        <div>
+          {showBackToSearch && onBackToSearch && (
+            <button onClick={onBackToSearch} className="p-1.5 rounded-lg hover:bg-gray-100 transition-colors">
+              <ChevronLeft className="w-5 h-5 text-gray-600" />
+            </button>
+          )}
+        </div>
         <h1 className="font-semibold text-gray-800 text-lg text-center truncate">Write Review</h1>
         <div className="flex justify-end">
           <button
@@ -428,17 +437,41 @@ const WriteReviewForm: React.FC = () => {
 
 const WriteReviewPage: React.FC = () => {
   const location = useLocation();
+  const navigate = useNavigate();
   const reviewContext = (location.state as WriteReviewLocationState | null) ?? null;
+
+  const [selectedMerchant, setSelectedMerchant] = useState<{
+    id: string;
+    name: string;
+    category: string;
+  } | null>(
+    reviewContext?.merchantId
+      ? { id: reviewContext.merchantId, name: reviewContext.merchantName ?? '', category: '' }
+      : null
+  );
+
+  // No merchantId from navigation state and none selected yet — show search
+  if (!selectedMerchant) {
+    return (
+      <MerchantSearchStep
+        onSelect={setSelectedMerchant}
+        onBack={() => navigate(-1)}
+      />
+    );
+  }
 
   return (
     <ReviewProvider
-      merchantId={reviewContext?.merchantId}
+      merchantId={selectedMerchant.id}
       storeId={reviewContext?.storeId}
       venueId={reviewContext?.venueId}
-      merchantName={reviewContext?.merchantName}
+      merchantName={selectedMerchant.name}
       merchantCategory={reviewContext?.merchantCategory ?? BusinessCategory.RESTAURANT}
     >
-      <WriteReviewForm />
+      <WriteReviewForm
+        showBackToSearch={!reviewContext?.merchantId}
+        onBackToSearch={() => setSelectedMerchant(null)}
+      />
     </ReviewProvider>
   );
 };

--- a/src/features/customer/reviews/pages/__tests__/WriteReviewPage.test.tsx
+++ b/src/features/customer/reviews/pages/__tests__/WriteReviewPage.test.tsx
@@ -45,8 +45,17 @@ test('renders upload, submit, and draft banners', async () => {
   reviewProviderSpy.mockClear();
   const { default: WriteReviewPage } = await import('../WriteReviewPage');
   render(
-    <MemoryRouter>
-      <WriteReviewPage />
+    <MemoryRouter
+      initialEntries={[
+        {
+          pathname: PATHS.CUSTOMER.WRITE_REVIEW,
+          state: { merchantId: '1', merchantName: 'Test' },
+        },
+      ]}
+    >
+      <Routes>
+        <Route path={PATHS.CUSTOMER.WRITE_REVIEW} element={<WriteReviewPage />} />
+      </Routes>
     </MemoryRouter>
   );
   expect(screen.getByText(/upload failed/i)).toBeInTheDocument();


### PR DESCRIPTION
## Summary
- Add merchant search/browse step when writing a review without a pre-selected merchant
- New `merchantsApi` client for `GET /merchants?search=&category=`
- New `MerchantSearchStep` component with debounced search input and merchant cards
- Existing flows (from merchant detail / profile pending reviews) unchanged

## Related
Closes #163
Backend counterpart: RevieU-Corp/revieu-backend#188

## Test plan
- [ ] Tap "+" in bottom nav → merchant search step appears
- [ ] Search by name filters the list with debounce
- [ ] Select a merchant → review form loads with correct merchantId
- [ ] Back button in review form returns to merchant search
- [ ] Navigate from merchant detail page → skips search, goes straight to form
- [ ] Navigate from profile pending reviews → skips search, goes straight to form

🤖 Generated with [Claude Code](https://claude.com/claude-code)