### PR TITLE
feat(web): wire merchant detail reviews to live api (#165)

### DIFF
--- a/docs/plans/2026-04-18-merchant-detail-reviews.md
+++ b/docs/plans/2026-04-18-merchant-detail-reviews.md
@@ -1,0 +1,113 @@
+# Merchant Detail Reviews Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Wire the merchant detail reviews surfaces to the live `GET /stores/:id/reviews` backend endpoint and remove the remaining placeholder/mock-only behavior.
+
+**Architecture:** Extend the existing frontend reviews API layer with a store-scoped query method, map backend store review payloads into a stable frontend shape, and reuse that mapped data in both the inline merchant detail reviews tab and the dedicated reviews route. Keep the current visual language, but replace placeholder and mock content with loading, empty, and error states driven by real API responses.
+
+**Tech Stack:** React 18, React Router, Axios, Vitest, Testing Library, TypeScript
+
+---
+
+### Task 1: Add store reviews API coverage
+
+**Files:**
+- Modify: `src/api/reviews.ts`
+- Test: `src/api/__tests__/reviews.test.ts`
+
+**Step 1: Write the failing test**
+
+Add a test asserting `reviewsApi.listStoreReviews('278', { limit: 20, cursor: '11' })` calls `/stores/278/reviews` with params and maps backend review fields, including user profile, scores, comments, and cursor.
+
+**Step 2: Run test to verify it fails**
+
+Run: `npm run test:run -- src/api/__tests__/reviews.test.ts`
+Expected: FAIL because `listStoreReviews` does not exist yet.
+
+**Step 3: Write minimal implementation**
+
+Implement store review request/response types and add `listStoreReviews` to `reviewsApi`, sharing mapping helpers where possible without changing existing `list()` behavior.
+
+**Step 4: Run test to verify it passes**
+
+Run: `npm run test:run -- src/api/__tests__/reviews.test.ts`
+Expected: PASS
+
+### Task 2: Replace dedicated merchant reviews page mock behavior
+
+**Files:**
+- Modify: `src/features/customer/pages/MerchantDetailPage/MerchantReviewsPage.tsx`
+- Modify: `src/features/customer/pages/MerchantDetailPage/components/ReviewListPage.tsx`
+- Test: `src/features/customer/pages/MerchantDetailPage/__tests__/MerchantReviewsPage.test.tsx`
+
+**Step 1: Write the failing test**
+
+Add a page test that renders `/customer/merchant/278/reviews`, mocks `reviewsApi.listStoreReviews`, and asserts:
+- loading transitions to real review content
+- API receives the route store id
+- empty state renders when the API returns no reviews
+
+**Step 2: Run test to verify it fails**
+
+Run: `npm run test:run -- src/features/customer/pages/MerchantDetailPage/__tests__/MerchantReviewsPage.test.tsx`
+Expected: FAIL because the page is still mock-only.
+
+**Step 3: Write minimal implementation**
+
+Refactor `ReviewListPage` to accept API-backed data props instead of hardcoded cards. Update `MerchantReviewsPage` to load store reviews, handle loading/error/empty states, and pass normalized data into the reusable list page.
+
+**Step 4: Run test to verify it passes**
+
+Run: `npm run test:run -- src/features/customer/pages/MerchantDetailPage/__tests__/MerchantReviewsPage.test.tsx`
+Expected: PASS
+
+### Task 3: Replace merchant detail reviews placeholder
+
+**Files:**
+- Modify: `src/features/customer/pages/MerchantDetailPage/components/RestaurantDetail.tsx`
+- Test: `src/features/customer/pages/MerchantDetailPage/__tests__/RestaurantDetail.test.tsx`
+
+**Step 1: Write the failing test**
+
+Add a component test asserting that when the Reviews tab is selected:
+- the component loads `/stores/:id/reviews` through `reviewsApi.listStoreReviews`
+- review cards render from API data
+- a real empty state appears when there are no reviews
+
+**Step 2: Run test to verify it fails**
+
+Run: `npm run test:run -- src/features/customer/pages/MerchantDetailPage/__tests__/RestaurantDetail.test.tsx`
+Expected: FAIL because the tab still renders placeholder copy.
+
+**Step 3: Write minimal implementation**
+
+Update `RestaurantDetail` to fetch reviews lazily when the reviews tab is opened, show a small API-backed review list, and surface loading/error/empty states in place of the placeholder text.
+
+**Step 4: Run test to verify it passes**
+
+Run: `npm run test:run -- src/features/customer/pages/MerchantDetailPage/__tests__/RestaurantDetail.test.tsx`
+Expected: PASS
+
+### Task 4: Verify integrated behavior
+
+**Files:**
+- Verify: `src/api/reviews.ts`
+- Verify: `src/features/customer/pages/MerchantDetailPage/MerchantReviewsPage.tsx`
+- Verify: `src/features/customer/pages/MerchantDetailPage/components/ReviewListPage.tsx`
+- Verify: `src/features/customer/pages/MerchantDetailPage/components/RestaurantDetail.tsx`
+
+**Step 1: Run focused test suite**
+
+Run: `npm run test:run -- src/api/__tests__/reviews.test.ts src/features/customer/pages/MerchantDetailPage/__tests__/MerchantReviewsPage.test.tsx src/features/customer/pages/MerchantDetailPage/__tests__/RestaurantDetail.test.tsx`
+Expected: PASS
+
+**Step 2: Run build verification**
+
+Run: `npm run build`
+Expected: PASS
+
+**Step 3: Review working tree**
+
+Run: `git status --short`
+Expected: only intended files are modified in the feature branch.

--- a/src/api/__tests__/reviews.test.ts
+++ b/src/api/__tests__/reviews.test.ts
@@ -115,4 +115,69 @@ describe('reviewsApi', () => {
     expect(response.total).toBe(7);
     expect(response.cursor).toBe('55');
   });
+
+  test('listStoreReviews calls paginated store-reviews API and maps live backend review fields', async () => {
+    mockGet.mockResolvedValue({
+      data: {
+        data: [
+          {
+            id: 12,
+            user_id: 211,
+            merchant_id: 202,
+            store_id: 278,
+            rating: 4.5,
+            rating_food: 4.5,
+            rating_env: 4.4,
+            rating_service: 4.5,
+            rating_value: 4.6,
+            content: 'Fresh tortillas, quick counter service, and a solid brunch combo.',
+            images: '["https://cdn.revieu.com/reviews/taco.jpg"]',
+            like_count: 3,
+            comment_count: 1,
+            is_liked: false,
+            created_at: '2026-03-25T09:52:52.842824Z',
+            visit_date: '2026-03-25T00:00:00Z',
+            user: {
+              id: 211,
+              profile: {
+                nickname: 'yanxia',
+                avatar_url: 'https://cdn.revieu.com/avatar.jpg',
+              },
+            },
+          },
+        ],
+        cursor: 11,
+      },
+    });
+
+    const response = await reviewsApi.listStoreReviews('278', { limit: 20, cursor: '11' });
+
+    expect(mockGet).toHaveBeenCalledWith('/stores/278/reviews', {
+      params: {
+        limit: 20,
+        cursor: '11',
+      },
+    });
+    expect(response.data).toHaveLength(1);
+    expect(response.data[0]).toMatchObject({
+      id: '12',
+      merchantId: '202',
+      storeId: '278',
+      userId: '211',
+      overallRating: 4.5,
+      text: 'Fresh tortillas, quick counter service, and a solid brunch combo.',
+      likeCount: 3,
+      commentCount: 1,
+      username: 'yanxia',
+      avatarUrl: 'https://cdn.revieu.com/avatar.jpg',
+    });
+    expect(response.data[0].images).toEqual(['https://cdn.revieu.com/reviews/taco.jpg']);
+    expect(response.data[0].detailedRatings).toMatchObject({
+      quality: 4.5,
+      environment: 4.4,
+      service: 4.5,
+      value: 4.6,
+    });
+    expect(response.cursor).toBe('11');
+  });
 });

--- a/src/api/reviews.ts
+++ b/src/api/reviews.ts
@@ -30,6 +30,7 @@ export interface ReviewResponse {
         quality: number;
         environment: number;
         service: number;
+        value?: number;
     };
     text?: string;
     images: string[];
@@ -45,9 +46,38 @@ export interface ReviewResponse {
     isLiked?: boolean;
 }
 
+export interface StoreReviewResponse {
+    id: string;
+    merchantId: string;
+    storeId: string;
+    userId: string;
+    overallRating: number;
+    detailedRatings?: {
+        quality: number;
+        environment: number;
+        service: number;
+        value?: number;
+    };
+    text?: string;
+    images: string[];
+    tags: string[];
+    visitDate?: string;
+    createdAt: string;
+    likeCount: number;
+    commentCount: number;
+    isLiked?: boolean;
+    username: string;
+    avatarUrl: string;
+}
+
 export interface ReviewListResponse {
     data: ReviewResponse[];
     total: number;
+    cursor?: string;
+}
+
+export interface StoreReviewListResponse {
+    data: StoreReviewResponse[];
     cursor?: string;
 }
 
@@ -91,15 +121,73 @@ interface BackendContentReviewItem {
     created_at: string;
 }
 
+interface BackendStoreReviewItem {
+    id: number;
+    user_id: number;
+    merchant_id: number;
+    store_id: number;
+    rating: number;
+    rating_food?: number;
+    rating_env?: number;
+    rating_service?: number;
+    rating_value?: number;
+    content: string;
+    images?: string[] | string;
+    tags?: string[] | string;
+    visit_date?: string;
+    like_count: number;
+    comment_count: number;
+    is_liked: boolean;
+    created_at: string;
+    user?: {
+        id: number;
+        profile?: {
+            nickname?: string;
+            avatar_url?: string;
+        };
+    };
+}
+
 interface BackendContentReviewListResponse {
     reviews: BackendContentReviewItem[];
     total: number;
     cursor?: number;
 }
 
+interface BackendStoreReviewListResponse {
+    data: BackendStoreReviewItem[];
+    cursor?: number;
+}
+
 export interface ReviewListRequest {
     cursor?: string;
     limit?: number;
+}
+
+function normalizeStringArray(value: string[] | string | undefined): string[] {
+    if (Array.isArray(value)) {
+        return value.filter((item): item is string => typeof item === 'string');
+    }
+
+    if (typeof value !== 'string') {
+        return [];
+    }
+
+    const trimmed = value.trim();
+    if (!trimmed) {
+        return [];
+    }
+
+    try {
+        const parsed = JSON.parse(trimmed);
+        if (Array.isArray(parsed)) {
+            return parsed.filter((item): item is string => typeof item === 'string');
+        }
+    } catch {
+        return [value];
+    }
+
+    return [];
 }
 
 function mapReviewResponse(review: BackendReviewResponse): ReviewResponse {
@@ -120,6 +208,32 @@ function mapReviewResponse(review: BackendReviewResponse): ReviewResponse {
         businessImage: review.businessImage,
         location: review.location,
         likeCount: review.likeCount,
+    };
+}
+
+function mapStoreReviewResponse(review: BackendStoreReviewItem): StoreReviewResponse {
+    return {
+        id: String(review.id),
+        merchantId: String(review.merchant_id),
+        storeId: String(review.store_id),
+        userId: String(review.user_id),
+        overallRating: review.rating,
+        detailedRatings: {
+            quality: review.rating_food ?? review.rating,
+            environment: review.rating_env ?? 0,
+            service: review.rating_service ?? 0,
+            value: review.rating_value ?? 0,
+        },
+        text: review.content,
+        images: normalizeStringArray(review.images),
+        tags: normalizeStringArray(review.tags),
+        visitDate: review.visit_date,
+        createdAt: review.created_at,
+        likeCount: review.like_count,
+        commentCount: review.comment_count,
+        isLiked: review.is_liked,
+        username: review.user?.profile?.nickname || `User ${review.user_id}`,
+        avatarUrl: review.user?.profile?.avatar_url ?? '',
     };
 }
 
@@ -166,8 +280,8 @@ export const reviewsApi = {
                     service: review.rating_service ?? 0,
                 },
                 text: review.content,
-                images: review.images ?? [],
-                tags: review.tags ?? [],
+                images: normalizeStringArray(review.images),
+                tags: normalizeStringArray(review.tags),
                 createdAt: review.created_at,
                 businessName: review.merchant.name,
                 businessImage: '',
@@ -177,6 +291,20 @@ export const reviewsApi = {
                 isLiked: review.is_liked,
             })),
             total: response.data.total,
+            cursor: response.data.cursor !== undefined ? String(response.data.cursor) : undefined,
+        };
+    },
+
+    listStoreReviews: async (storeId: string, request: ReviewListRequest = {}): Promise<StoreReviewListResponse> => {
+        const response = await apiClient.get<BackendStoreReviewListResponse>(`/stores/${storeId}/reviews`, {
+            params: {
+                cursor: request.cursor,
+                limit: request.limit,
+            },
+        });
+
+        return {
+            data: response.data.data.map(mapStoreReviewResponse),
             cursor: response.data.cursor !== undefined ? String(response.data.cursor) : undefined,
         };
     },

--- a/src/features/customer/pages/MerchantDetailPage/MerchantReviewsPage.tsx
+++ b/src/features/customer/pages/MerchantDetailPage/MerchantReviewsPage.tsx
@@ -1,17 +1,171 @@
+import { useEffect, useMemo, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
-import { ReviewListPage } from './components/ReviewListPage';
+import { apiClient } from '../../../../api/apiClient';
+import { reviewsApi, StoreReviewResponse } from '../../../../api/reviews';
+import { MerchantReviewListItem, MerchantReviewSummary, ReviewListPage } from './components/ReviewListPage';
+
+const REVIEW_PAGE_SIZE = 20;
+
+interface BackendStoreDetail {
+  id: number;
+  merchant_id: number;
+  name: string;
+  avg_rating?: number | null;
+  review_count?: number | null;
+}
+
+interface StoreSummary {
+  name: string;
+  avgRating: number;
+  reviewCount: number;
+}
+
+function mapStoreSummary(raw: BackendStoreDetail): StoreSummary {
+  return {
+    name: raw.name,
+    avgRating: raw.avg_rating ?? 0,
+    reviewCount: raw.review_count ?? 0,
+  };
+}
+
+function formatReviewDate(value: string): string {
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    return 'Recently';
+  }
+
+  return parsed.toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  });
+}
+
+function getAvatarLabel(username: string): string {
+  const trimmed = username.trim();
+  if (!trimmed) {
+    return 'R';
+  }
+
+  return trimmed.charAt(0).toUpperCase();
+}
+
+function average(values: number[]): number {
+  if (values.length === 0) {
+    return 0;
+  }
+
+  return values.reduce((sum, value) => sum + value, 0) / values.length;
+}
+
+function mapReviewsToCards(reviews: StoreReviewResponse[]): MerchantReviewListItem[] {
+  return reviews.map((review) => ({
+    id: review.id,
+    username: review.username,
+    avatarLabel: getAvatarLabel(review.username),
+    rating: Math.round(review.overallRating),
+    tasteScore: review.detailedRatings?.quality ?? review.overallRating,
+    envScore: review.detailedRatings?.environment ?? review.overallRating,
+    serviceScore: review.detailedRatings?.service ?? review.overallRating,
+    date: formatReviewDate(review.createdAt),
+    comment: review.text ?? '',
+    tags: review.tags,
+    images: review.images,
+    helpful: review.likeCount,
+  }));
+}
+
+function buildSummary(store: StoreSummary | null, reviews: StoreReviewResponse[]): MerchantReviewSummary {
+  const tasteValues = reviews
+    .map((review) => review.detailedRatings?.quality)
+    .filter((value): value is number => typeof value === 'number' && value > 0);
+  const envValues = reviews
+    .map((review) => review.detailedRatings?.environment)
+    .filter((value): value is number => typeof value === 'number' && value > 0);
+  const serviceValues = reviews
+    .map((review) => review.detailedRatings?.service)
+    .filter((value): value is number => typeof value === 'number' && value > 0);
+  const overallRatings = reviews
+    .map((review) => review.overallRating)
+    .filter((value): value is number => typeof value === 'number' && value > 0);
+
+  return {
+    storeName: store?.name ?? 'Store Reviews',
+    overallRating: store?.avgRating || average(overallRatings),
+    reviewCount: store?.reviewCount ?? reviews.length,
+    tasteScore: average(tasteValues) || store?.avgRating || 0,
+    envScore: average(envValues) || store?.avgRating || 0,
+    serviceScore: average(serviceValues) || store?.avgRating || 0,
+  };
+}
 
 const MerchantReviewsPage: React.FC = () => {
   const navigate = useNavigate();
   const { id } = useParams<{ id: string }>();
+  const [store, setStore] = useState<StoreSummary | null>(null);
+  const [reviews, setReviews] = useState<StoreReviewResponse[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const loadPage = async () => {
+      if (!id) {
+        setError('Store id is missing.');
+        setIsLoading(false);
+        return;
+      }
+
+      setIsLoading(true);
+      setError(null);
+
+      const [storeResult, reviewsResult] = await Promise.allSettled([
+        apiClient.get<{ data: BackendStoreDetail }>(`/stores/${id}`),
+        reviewsApi.listStoreReviews(id, { limit: REVIEW_PAGE_SIZE }),
+      ]);
+
+      if (cancelled) {
+        return;
+      }
+
+      if (storeResult.status === 'fulfilled') {
+        setStore(mapStoreSummary(storeResult.value.data.data));
+      }
+
+      if (reviewsResult.status === 'fulfilled') {
+        setReviews(reviewsResult.value.data);
+      } else {
+        setReviews([]);
+        setError('Failed to load reviews.');
+      }
+
+      setIsLoading(false);
+    };
+
+    void loadPage();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [id]);
 
   const handleBack = () => {
-    // 返回到商户详情页面
     navigate(`/customer/merchant/${id || '1'}`);
   };
 
+  const summary = useMemo(() => buildSummary(store, reviews), [reviews, store]);
+  const reviewCards = useMemo(() => mapReviewsToCards(reviews), [reviews]);
+
   return (
-    <ReviewListPage onBack={handleBack} />
+    <ReviewListPage
+      onBack={handleBack}
+      summary={summary}
+      reviews={reviewCards}
+      isLoading={isLoading}
+      error={error}
+      emptyMessage="No reviews for this store yet."
+    />
   );
 };
 

--- a/src/features/customer/pages/MerchantDetailPage/__tests__/MerchantReviewsPage.test.tsx
+++ b/src/features/customer/pages/MerchantDetailPage/__tests__/MerchantReviewsPage.test.tsx
@@ -1,0 +1,110 @@
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+
+const { listStoreReviewsMock, storeDetailGetMock } = vi.hoisted(() => ({
+  listStoreReviewsMock: vi.fn(),
+  storeDetailGetMock: vi.fn(),
+}));
+
+vi.mock('../../../../../api/reviews', () => ({
+  reviewsApi: {
+    listStoreReviews: listStoreReviewsMock,
+  },
+}));
+
+vi.mock('../../../../../api/apiClient', () => ({
+  apiClient: {
+    get: storeDetailGetMock,
+  },
+}));
+
+describe('MerchantReviewsPage', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  beforeEach(() => {
+    listStoreReviewsMock.mockReset();
+    storeDetailGetMock.mockReset();
+    storeDetailGetMock.mockResolvedValue({
+      data: {
+        data: {
+          id: 278,
+          merchant_id: 202,
+          name: 'Lone Star Taco Bar',
+          avg_rating: 4.5,
+          review_count: 1,
+        },
+      },
+    });
+  });
+
+  it('loads reviews for the route store id and renders live review content', async () => {
+    listStoreReviewsMock.mockResolvedValue({
+      data: [
+        {
+          id: '12',
+          merchantId: '202',
+          storeId: '278',
+          userId: '211',
+          overallRating: 4.5,
+          detailedRatings: {
+            quality: 4.5,
+            environment: 4.4,
+            service: 4.5,
+            value: 4.6,
+          },
+          text: 'Fresh tortillas, quick counter service, and a solid brunch combo.',
+          images: ['https://cdn.revieu.com/reviews/taco.jpg'],
+          tags: ['#Fresh', '#Quick'],
+          createdAt: '2026-03-25T09:52:52.842824Z',
+          likeCount: 3,
+          commentCount: 1,
+          username: 'yanxia',
+          avatarUrl: 'https://cdn.revieu.com/avatar.jpg',
+        },
+      ],
+    });
+
+    const { default: MerchantReviewsPage } = await import('../MerchantReviewsPage');
+
+    render(
+      <MemoryRouter initialEntries={['/customer/merchant/278/reviews']}>
+        <Routes>
+          <Route path="/customer/merchant/:id/reviews" element={<MerchantReviewsPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText('Loading reviews...')).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(listStoreReviewsMock).toHaveBeenCalledWith('278', { limit: 20 });
+    });
+
+    expect(await screen.findByText('Fresh tortillas, quick counter service, and a solid brunch combo.')).toBeInTheDocument();
+    expect(screen.getByText('Lone Star Taco Bar')).toBeInTheDocument();
+    expect(screen.getByText('yanxia')).toBeInTheDocument();
+  });
+
+  it('renders a real empty state when the store has no reviews', async () => {
+    listStoreReviewsMock.mockResolvedValue({
+      data: [],
+    });
+
+    const { default: MerchantReviewsPage } = await import('../MerchantReviewsPage');
+
+    render(
+      <MemoryRouter initialEntries={['/customer/merchant/278/reviews']}>
+        <Routes>
+          <Route path="/customer/merchant/:id/reviews" element={<MerchantReviewsPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText('No reviews for this store yet.')).toBeInTheDocument();
+    expect(screen.queryByText('Loading reviews...')).not.toBeInTheDocument();
+  });
+});

--- a/src/features/customer/pages/MerchantDetailPage/__tests__/RestaurantDetail.test.tsx
+++ b/src/features/customer/pages/MerchantDetailPage/__tests__/RestaurantDetail.test.tsx
@@ -1,0 +1,127 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
+
+const { mockGet, listStoreReviewsMock, getAvailableCouponsMock } = vi.hoisted(() => ({
+  mockGet: vi.fn(),
+  listStoreReviewsMock: vi.fn(),
+  getAvailableCouponsMock: vi.fn(),
+}));
+
+vi.mock('../../../../../api/apiClient', () => ({
+  apiClient: {
+    get: mockGet,
+  },
+}));
+
+vi.mock('../../../shared/services/couponService', () => ({
+  couponService: {
+    getAvailableCoupons: getAvailableCouponsMock,
+  },
+}));
+
+vi.mock('../../../../../api/reviews', () => ({
+  reviewsApi: {
+    listStoreReviews: listStoreReviewsMock,
+  },
+}));
+
+describe('RestaurantDetail', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  beforeEach(() => {
+    mockGet.mockReset();
+    listStoreReviewsMock.mockReset();
+    getAvailableCouponsMock.mockReset();
+
+    mockGet.mockResolvedValue({
+      data: {
+        data: {
+          id: 278,
+          merchant_id: 202,
+          name: 'Lone Star Taco Bar',
+          description: 'Austin-style tacos, aguas frescas, and weekend brunch.',
+          address: '501 Congress Ave',
+          city: 'Austin',
+          state: 'TX',
+          country: 'USA',
+          phone: '(512) 555-0278',
+          cover_image_url: 'https://img.example/cover.jpg',
+          avg_rating: 4.5,
+          review_count: 1,
+        },
+      },
+    });
+    getAvailableCouponsMock.mockResolvedValue([]);
+  });
+
+  it('loads live reviews when the reviews tab is opened', async () => {
+    listStoreReviewsMock.mockResolvedValue({
+      data: [
+        {
+          id: '12',
+          merchantId: '202',
+          storeId: '278',
+          userId: '211',
+          overallRating: 4.5,
+          detailedRatings: {
+            quality: 4.5,
+            environment: 4.4,
+            service: 4.5,
+            value: 4.6,
+          },
+          text: 'Fresh tortillas, quick counter service, and a solid brunch combo.',
+          images: ['https://cdn.revieu.com/reviews/taco.jpg'],
+          tags: ['#Fresh', '#Quick'],
+          createdAt: '2026-03-25T09:52:52.842824Z',
+          likeCount: 3,
+          commentCount: 1,
+          username: 'yanxia',
+          avatarUrl: 'https://cdn.revieu.com/avatar.jpg',
+        },
+      ],
+    });
+
+    const { RestaurantDetail } = await import('../components/RestaurantDetail');
+
+    render(
+      <MemoryRouter>
+        <RestaurantDetail storeId="278" />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText('Lone Star Taco Bar')).toBeInTheDocument();
+
+    fireEvent.click(screen.getAllByRole('button', { name: /reviews/i })[0]);
+
+    await waitFor(() => {
+      expect(listStoreReviewsMock).toHaveBeenCalledWith('278', { limit: 3 });
+    });
+
+    expect(await screen.findByText('Fresh tortillas, quick counter service, and a solid brunch combo.')).toBeInTheDocument();
+    expect(screen.queryByText(/Reviews are not wired into this page yet/i)).not.toBeInTheDocument();
+  });
+
+  it('renders a real empty state in the reviews tab when the api returns no reviews', async () => {
+    listStoreReviewsMock.mockResolvedValue({
+      data: [],
+    });
+
+    const { RestaurantDetail } = await import('../components/RestaurantDetail');
+
+    render(
+      <MemoryRouter>
+        <RestaurantDetail storeId="278" />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText('Lone Star Taco Bar')).toBeInTheDocument();
+
+    fireEvent.click(screen.getAllByRole('button', { name: /reviews/i })[0]);
+
+    expect(await screen.findByText('No reviews for this store yet.')).toBeInTheDocument();
+  });
+});

--- a/src/features/customer/pages/MerchantDetailPage/components/RestaurantDetail.tsx
+++ b/src/features/customer/pages/MerchantDetailPage/components/RestaurantDetail.tsx
@@ -1,10 +1,13 @@
 import { useEffect, useState } from 'react';
 import { MapPin, Phone, Star, Ticket, MenuSquare, MessageCircle } from 'lucide-react';
+import { useNavigate } from 'react-router-dom';
 import { apiClient } from '../../../../../api/apiClient';
+import { reviewsApi, StoreReviewResponse } from '../../../../../api/reviews';
 import { couponService } from '../../../shared/services/couponService';
 import { Coupon, MerchantInfo } from '../../../shared/types/coupons';
 import { DealCard } from './DealCard';
 import { ImageWithFallback } from './ImageWithFallback';
+import { ReviewListCard } from './ReviewListCard';
 
 interface RestaurantDetailProps {
   storeId?: string;
@@ -71,12 +74,39 @@ const mapStore = (raw: BackendStore): StoreDetail => {
   };
 };
 
+function formatReviewDate(value: string): string {
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    return 'Recently';
+  }
+
+  return parsed.toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  });
+}
+
+function getAvatarLabel(username: string): string {
+  const trimmed = username.trim();
+  if (!trimmed) {
+    return 'R';
+  }
+
+  return trimmed.charAt(0).toUpperCase();
+}
+
 export function RestaurantDetail({ storeId, onBack }: RestaurantDetailProps) {
+  const navigate = useNavigate();
   const [activeTab, setActiveTab] = useState<'deals' | 'menu' | 'reviews'>('deals');
   const [store, setStore] = useState<StoreDetail>(FALLBACK_STORE);
   const [coupons, setCoupons] = useState<Coupon[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [reviewPreview, setReviewPreview] = useState<StoreReviewResponse[]>([]);
+  const [reviewPreviewLoading, setReviewPreviewLoading] = useState(false);
+  const [reviewPreviewLoaded, setReviewPreviewLoaded] = useState(false);
+  const [reviewPreviewError, setReviewPreviewError] = useState<string | null>(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -122,6 +152,52 @@ export function RestaurantDetail({ storeId, onBack }: RestaurantDetailProps) {
       cancelled = true;
     };
   }, [storeId]);
+
+  useEffect(() => {
+    setReviewPreview([]);
+    setReviewPreviewLoading(false);
+    setReviewPreviewLoaded(false);
+    setReviewPreviewError(null);
+  }, [storeId]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const loadReviewPreview = async () => {
+      if (!storeId || activeTab !== 'reviews' || reviewPreviewLoaded) {
+        return;
+      }
+
+      setReviewPreviewLoading(true);
+      setReviewPreviewError(null);
+
+      try {
+        const response = await reviewsApi.listStoreReviews(storeId, { limit: 3 });
+        if (cancelled) {
+          return;
+        }
+
+        setReviewPreview(response.data);
+      } catch (loadError) {
+        if (!cancelled) {
+          console.error('Failed to load review preview:', loadError);
+          setReviewPreview([]);
+          setReviewPreviewError('Failed to load reviews.');
+        }
+      } finally {
+        if (!cancelled) {
+          setReviewPreviewLoading(false);
+          setReviewPreviewLoaded(true);
+        }
+      }
+    };
+
+    void loadReviewPreview();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [activeTab, reviewPreviewLoaded, storeId]);
 
   const merchantInfo: MerchantInfo = {
     id: store.merchantId,
@@ -249,8 +325,56 @@ export function RestaurantDetail({ storeId, onBack }: RestaurantDetailProps) {
         )}
 
         {activeTab === 'reviews' && (
-          <div className="mt-8 rounded-3xl border border-dashed border-gray-200 bg-gray-50 px-5 py-8 text-center text-sm text-gray-500">
-            Reviews are not wired into this page yet. The next backend-aligned step is `/stores/:id/reviews`.
+          <div className="mt-8 space-y-4">
+            <div className="flex items-center justify-between">
+              <h2 className="text-xl font-bold text-gray-900">Community Reviews</h2>
+              <button
+                type="button"
+                onClick={() => navigate(`/customer/merchant/${store.id || storeId || '1'}/reviews`)}
+                className="rounded-full border border-gray-200 px-4 py-2 text-sm font-semibold text-gray-700 transition hover:border-[#FF6900] hover:text-[#FF6900]"
+              >
+                View all reviews
+              </button>
+            </div>
+
+            {reviewPreviewLoading && (
+              <div className="rounded-3xl border border-dashed border-gray-200 bg-gray-50 px-5 py-8 text-center text-sm text-gray-500">
+                Loading reviews...
+              </div>
+            )}
+
+            {!reviewPreviewLoading && reviewPreviewError && (
+              <div className="rounded-2xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800">
+                {reviewPreviewError}
+              </div>
+            )}
+
+            {!reviewPreviewLoading && !reviewPreviewError && reviewPreview.length === 0 && (
+              <div className="rounded-3xl border border-dashed border-gray-200 bg-gray-50 px-5 py-8 text-center text-sm text-gray-500">
+                No reviews for this store yet.
+              </div>
+            )}
+
+            {!reviewPreviewLoading && !reviewPreviewError && reviewPreview.length > 0 && (
+              <div className="space-y-3">
+                {reviewPreview.map((review) => (
+                  <ReviewListCard
+                    key={review.id}
+                    username={review.username}
+                    avatar={getAvatarLabel(review.username)}
+                    rating={Math.round(review.overallRating)}
+                    tasteScore={review.detailedRatings?.quality ?? review.overallRating}
+                    envScore={review.detailedRatings?.environment ?? review.overallRating}
+                    serviceScore={review.detailedRatings?.service ?? review.overallRating}
+                    date={formatReviewDate(review.createdAt)}
+                    comment={review.text ?? ''}
+                    tags={review.tags}
+                    images={review.images}
+                    helpful={review.likeCount}
+                  />
+                ))}
+              </div>
+            )}
           </div>
         )}
       </div>

--- a/src/features/customer/pages/MerchantDetailPage/components/ReviewListPage.tsx
+++ b/src/features/customer/pages/MerchantDetailPage/components/ReviewListPage.tsx
@@ -1,202 +1,203 @@
-import { useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { ArrowLeft, Star } from 'lucide-react';
 import { ReviewListCard } from './ReviewListCard';
 
-interface ReviewListPageProps {
-  onBack?: () => void;
+export interface MerchantReviewListItem {
+  id: string;
+  username: string;
+  avatarLabel: string;
+  rating: number;
+  tasteScore: number;
+  envScore: number;
+  serviceScore: number;
+  date: string;
+  comment: string;
+  tags: string[];
+  images?: string[];
+  helpful: number;
 }
 
-export function ReviewListPage({ onBack }: ReviewListPageProps) {
-  const [activeFilter, setActiveFilter] = useState('#Fresh');
-  const filters = ['#Fresh', '#GoodService', '#Cozy', '#Affordable', '#Authentic', '#Quick'];
+export interface MerchantReviewSummary {
+  storeName: string;
+  overallRating: number;
+  reviewCount: number;
+  tasteScore: number;
+  envScore: number;
+  serviceScore: number;
+}
+
+interface ReviewListPageProps {
+  onBack?: () => void;
+  summary: MerchantReviewSummary;
+  reviews: MerchantReviewListItem[];
+  isLoading?: boolean;
+  error?: string | null;
+  emptyMessage?: string;
+}
+
+export function ReviewListPage({
+  onBack,
+  summary,
+  reviews,
+  isLoading = false,
+  error = null,
+  emptyMessage = 'No reviews yet.',
+}: ReviewListPageProps) {
+  const filters = useMemo(() => {
+    const tagSet = new Set<string>();
+    reviews.forEach((review) => {
+      review.tags.forEach((tag) => {
+        if (tag) {
+          tagSet.add(tag);
+        }
+      });
+    });
+
+    return ['All', ...Array.from(tagSet)];
+  }, [reviews]);
+  const [activeFilter, setActiveFilter] = useState('All');
+
+  useEffect(() => {
+    setActiveFilter('All');
+  }, [filters.join('|'), summary.storeName]);
+
+  const filteredReviews = useMemo(() => {
+    if (activeFilter === 'All') {
+      return reviews;
+    }
+
+    return reviews.filter((review) => review.tags.includes(activeFilter));
+  }, [activeFilter, reviews]);
 
   return (
     <div className="min-h-screen bg-white">
-      {/* Header */}
-      <div className="sticky top-0 bg-white border-b border-gray-200 z-20">
-        <div className="flex items-center px-4 h-14">
-          <button onClick={onBack} className="mr-3">
-            <ArrowLeft className="w-6 h-6 text-gray-900" />
+      <div className="sticky top-0 z-20 border-b border-gray-200 bg-white">
+        <div className="flex h-14 items-center px-4">
+          <button type="button" onClick={onBack} className="mr-3">
+            <ArrowLeft className="h-6 w-6 text-gray-900" />
           </button>
           <h1 className="text-lg font-bold text-gray-900">Reviews</h1>
         </div>
       </div>
 
-      <div className="px-4 py-4 space-y-4">
-        {/* Overall Rating Summary Card */}
-        <div className="bg-white rounded-2xl shadow-sm border border-gray-200 p-5">
-          {/* Title with gradient bar */}
-          <div className="flex items-center gap-3 mb-4">
-            <div 
-              className="w-1 h-6 rounded-full"
+      <div className="space-y-4 px-4 py-4">
+        <div className="rounded-2xl border border-gray-200 bg-white p-5 shadow-sm">
+          <div className="mb-2 flex items-center gap-3">
+            <div
+              className="h-6 w-1 rounded-full"
               style={{
-                background: 'linear-gradient(180deg, #FFA500 0%, #DC2626 100%)'
+                background: 'linear-gradient(180deg, #FFA500 0%, #DC2626 100%)',
               }}
             />
-            <h2 className="font-bold text-lg text-gray-900">Overall Rating</h2>
+            <h2 className="text-lg font-bold text-gray-900">Overall Rating</h2>
           </div>
+          <p className="mb-4 text-sm font-medium text-gray-500">{summary.storeName}</p>
 
-          {/* Rating Content */}
           <div className="flex items-start gap-6">
-            {/* Large Rating Number */}
             <div className="text-center">
-              <div className="text-5xl font-bold text-gray-900 mb-1">4.8</div>
-              <div className="flex items-center gap-1 mb-1">
+              <div className="mb-1 text-5xl font-bold text-gray-900">{summary.overallRating.toFixed(1)}</div>
+              <div className="mb-1 flex items-center gap-1">
                 {[1, 2, 3, 4, 5].map((star) => (
-                  <Star key={star} className="w-4 h-4 fill-[#FFA500] text-[#FFA500]" />
+                  <Star
+                    key={star}
+                    className={`h-4 w-4 ${
+                      star <= Math.round(summary.overallRating)
+                        ? 'fill-[#FFA500] text-[#FFA500]'
+                        : 'fill-gray-200 text-gray-200'
+                    }`}
+                  />
                 ))}
               </div>
-              <p className="text-xs text-gray-500">324 reviews</p>
+              <p className="text-xs text-gray-500">{summary.reviewCount} reviews</p>
             </div>
 
-            {/* Progress Bars */}
             <div className="flex-1 space-y-3">
-              {/* Taste */}
-              <div>
-                <div className="flex items-center justify-between mb-1">
-                  <span className="text-sm font-medium text-gray-700">Taste</span>
-                  <span className="text-sm font-bold text-gray-900">4.9</span>
-                </div>
-                <div className="h-2 bg-gray-100 rounded-full overflow-hidden">
-                  <div 
-                    className="h-full rounded-full"
-                    style={{
-                      width: '98%',
-                      background: 'linear-gradient(90deg, #FFA500 0%, #FF8C00 100%)'
-                    }}
-                  />
-                </div>
-              </div>
+              {[
+                { label: 'Taste', score: summary.tasteScore },
+                { label: 'Environment', score: summary.envScore },
+                { label: 'Service', score: summary.serviceScore },
+              ].map(({ label, score }) => {
+                const width = `${Math.max(0, Math.min(100, Math.round((score / 5) * 100)))}%`;
 
-              {/* Environment */}
-              <div>
-                <div className="flex items-center justify-between mb-1">
-                  <span className="text-sm font-medium text-gray-700">Environment</span>
-                  <span className="text-sm font-bold text-gray-900">4.7</span>
-                </div>
-                <div className="h-2 bg-gray-100 rounded-full overflow-hidden">
-                  <div 
-                    className="h-full rounded-full"
-                    style={{
-                      width: '94%',
-                      background: 'linear-gradient(90deg, #FFA500 0%, #FF8C00 100%)'
-                    }}
-                  />
-                </div>
-              </div>
-
-              {/* Service */}
-              <div>
-                <div className="flex items-center justify-between mb-1">
-                  <span className="text-sm font-medium text-gray-700">Service</span>
-                  <span className="text-sm font-bold text-gray-900">4.8</span>
-                </div>
-                <div className="h-2 bg-gray-100 rounded-full overflow-hidden">
-                  <div 
-                    className="h-full rounded-full"
-                    style={{
-                      width: '96%',
-                      background: 'linear-gradient(90deg, #FFA500 0%, #FF8C00 100%)'
-                    }}
-                  />
-                </div>
-              </div>
+                return (
+                  <div key={label}>
+                    <div className="mb-1 flex items-center justify-between">
+                      <span className="text-sm font-medium text-gray-700">{label}</span>
+                      <span className="text-sm font-bold text-gray-900">{score.toFixed(1)}</span>
+                    </div>
+                    <div className="h-2 overflow-hidden rounded-full bg-gray-100">
+                      <div
+                        className="h-full rounded-full"
+                        style={{
+                          width,
+                          background: 'linear-gradient(90deg, #FFA500 0%, #FF8C00 100%)',
+                        }}
+                      />
+                    </div>
+                  </div>
+                );
+              })}
             </div>
           </div>
         </div>
 
-        {/* Filter Section */}
-        <div className="flex gap-2 overflow-x-auto pb-2 -mx-4 px-4 scrollbar-hide">
-          {filters.map((filter) => (
-            <button
-              key={filter}
-              onClick={() => setActiveFilter(filter)}
-              className={`px-4 py-2 rounded-full text-sm font-medium whitespace-nowrap transition-all ${
-                activeFilter === filter
-                  ? 'bg-orange-50 text-[#FFA500] border-2 border-[#FFA500]'
-                  : 'bg-gray-50 text-gray-600 border border-gray-200'
-              }`}
-            >
-              {filter}
-            </button>
-          ))}
-        </div>
+        {filters.length > 1 && (
+          <div className="-mx-4 flex gap-2 overflow-x-auto px-4 pb-2 scrollbar-hide">
+            {filters.map((filter) => (
+              <button
+                key={filter}
+                type="button"
+                onClick={() => setActiveFilter(filter)}
+                className={`whitespace-nowrap rounded-full px-4 py-2 text-sm font-medium transition-all ${
+                  activeFilter === filter
+                    ? 'border-2 border-[#FFA500] bg-orange-50 text-[#FFA500]'
+                    : 'border border-gray-200 bg-gray-50 text-gray-600'
+                }`}
+              >
+                {filter}
+              </button>
+            ))}
+          </div>
+        )}
 
-        {/* Review List */}
-        <div className="space-y-3">
-          <ReviewListCard
-            username="Sarah Johnson"
-            avatar="👩‍🦰"
-            rating={5}
-            tasteScore={5.0}
-            envScore={4.8}
-            serviceScore={5.0}
-            date="3 days ago"
-            comment="Absolutely amazing experience! The food was incredibly fresh and flavorful. The orange chicken is a must-try - perfectly crispy with just the right amount of sauce."
-            tags={['#Fresh', '#GoodService', '#Authentic']}
-            images={[
-              "https://images.unsplash.com/photo-1758275682464-ddd906bf34fe?w=200&q=80",
-              "https://images.unsplash.com/photo-1767429013002-69b35cb45395?w=200&q=80",
-              "https://images.unsplash.com/photo-1652937916838-09b9c2ff8b45?w=200&q=80"
-            ]}
-            helpful={47}
-          />
-          <ReviewListCard
-            username="Michael Chen"
-            avatar="👨"
-            rating={5}
-            tasteScore={5.0}
-            envScore={5.0}
-            serviceScore={4.5}
-            date="1 week ago"
-            comment="Best Chinese restaurant near campus! The portions are generous and the quality is consistently excellent. Great spot for a quick lunch between classes."
-            tags={['#Affordable', '#Quick', '#Fresh']}
-            helpful={32}
-          />
-          <ReviewListCard
-            username="Emily Rodriguez"
-            avatar="👩"
-            rating={4}
-            tasteScore={4.5}
-            envScore={4.0}
-            serviceScore={4.5}
-            date="2 weeks ago"
-            comment="Really enjoyed the noodle dishes here. The atmosphere is nice and cozy, perfect for studying or catching up with friends. Service can be a bit slow during peak hours though."
-            tags={['#Cozy', '#GoodService']}
-            images={[
-              "https://images.unsplash.com/photo-1630914441934-a29bf360934c?w=200&q=80"
-            ]}
-            helpful={28}
-          />
-          <ReviewListCard
-            username="David Park"
-            avatar="🧑"
-            rating={5}
-            tasteScore={5.0}
-            envScore={4.5}
-            serviceScore={5.0}
-            date="3 weeks ago"
-            comment="The staff here are so friendly and remember regular customers. Food quality is top-notch and they're always consistent. Highly recommend the lunch combos!"
-            tags={['#GoodService', '#Affordable', '#Authentic']}
-            helpful={51}
-          />
-          <ReviewListCard
-            username="Lisa Wang"
-            avatar="👱‍♀️"
-            rating={5}
-            tasteScore={4.8}
-            envScore={4.7}
-            serviceScore={5.0}
-            date="1 month ago"
-            comment="Love this place! The dumplings are handmade and you can taste the difference. Clean environment and great value for money. Will definitely be back!"
-            tags={['#Fresh', '#Cozy', '#Authentic']}
-            images={[
-              "https://images.unsplash.com/photo-1763689389824-dd2cea2e5772?w=200&q=80",
-              "https://images.unsplash.com/photo-1767429013002-69b35cb45395?w=200&q=80"
-            ]}
-            helpful={39}
-          />
-        </div>
+        {isLoading && (
+          <div className="rounded-3xl border border-dashed border-gray-200 bg-gray-50 px-5 py-8 text-center text-sm text-gray-500">
+            Loading reviews...
+          </div>
+        )}
+
+        {!isLoading && error && (
+          <div className="rounded-2xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800">
+            {error}
+          </div>
+        )}
+
+        {!isLoading && !error && filteredReviews.length === 0 && (
+          <div className="rounded-3xl border border-dashed border-gray-200 bg-gray-50 px-5 py-8 text-center text-sm text-gray-500">
+            {emptyMessage}
+          </div>
+        )}
+
+        {!isLoading && !error && filteredReviews.length > 0 && (
+          <div className="space-y-3">
+            {filteredReviews.map((review) => (
+              <ReviewListCard
+                key={review.id}
+                username={review.username}
+                avatar={review.avatarLabel}
+                rating={review.rating}
+                tasteScore={review.tasteScore}
+                envScore={review.envScore}
+                serviceScore={review.serviceScore}
+                date={review.date}
+                comment={review.comment}
+                tags={review.tags}
+                images={review.images}
+                helpful={review.helpful}
+              />
+            ))}
+          </div>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- add a store reviews client for `GET /stores/:id/reviews` and normalize live backend review payloads
- replace the mocked merchant reviews route with API-backed loading, empty, and error states
- load live review previews in the merchant detail Reviews tab and cover the new flow with regression tests

## Test Plan
- [x] `npm run test:run`
- [x] `npm run build`

Closes #165