### PR TITLE
fix(web): add store-scoped write review selector (#167)

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -5,7 +5,7 @@ import { PATHS } from '../routes/paths';
 import { LoginPage, MerchantLoginPage, RegisterPage, ForgotPasswordPage, GoogleCallbackPage } from '../features/auth';
 import {
   HomePage, DiscoverPage, ExplorePage, ProfilePage, ProfileSettingsPage,
-  CustomerLayout, VouchersPage, VoucherDisplay, ReviewsPage, WriteReviewPage, ReviewSuccessPage, PostPage, MerchantDetailPage, MerchantReviewsPage,
+  CustomerLayout, VouchersPage, VoucherDisplay, ReviewsPage, WriteReviewPage, WriteReviewSelectPage, ReviewSuccessPage, PostPage, MerchantDetailPage, MerchantReviewsPage,
   MerchantProfileCouponPage, PaymentPage, PaymentSuccessPage, CouponPaymentSuccessPage, DealQrPage
 } from '../features/customer';
 
@@ -56,6 +56,7 @@ const AppRouter: React.FC = () => {
         <Route path={PATHS.CUSTOMER.MERCHANT_PROFILE_COUPON_DETAIL} element={<MerchantProfileCouponPage />} />
         <Route path={PATHS.CUSTOMER.MERCHANT_DEAL_QR_DETAIL} element={<DealQrPage />} />
         <Route path="/customer/merchant/:id/reviews" element={<MerchantReviewsPage />} />
+        <Route path={PATHS.CUSTOMER.WRITE_REVIEW_SELECT} element={<WriteReviewSelectPage />} />
         <Route path={PATHS.CUSTOMER.WRITE_REVIEW} element={<WriteReviewPage />} />
         <Route path={PATHS.CUSTOMER.REVIEW_SUCCESS} element={<ReviewSuccessPage />} />
         <Route path="/customer/payment" element={<PaymentPage />} />

--- a/src/features/customer/pages/MerchantDetailPage/components/GlossyBottomNav.tsx
+++ b/src/features/customer/pages/MerchantDetailPage/components/GlossyBottomNav.tsx
@@ -22,7 +22,7 @@ export function GlossyBottomNav({ onBack, onWriteReview }: GlossyBottomNavProps)
     if (onWriteReview) {
       onWriteReview();
     } else {
-      navigate(PATHS.CUSTOMER.WRITE_REVIEW);
+      navigate(PATHS.CUSTOMER.WRITE_REVIEW_SELECT);
     }
   };
 

--- a/src/features/customer/pages/MerchantDetailPage/components/RestaurantDetail.tsx
+++ b/src/features/customer/pages/MerchantDetailPage/components/RestaurantDetail.tsx
@@ -1,8 +1,10 @@
 import { useEffect, useState } from 'react';
 import { MapPin, Phone, Star, Ticket, MenuSquare, MessageCircle } from 'lucide-react';
+import { useNavigate } from 'react-router-dom';
 import { apiClient } from '../../../../../api/apiClient';
 import { couponService } from '../../../shared/services/couponService';
 import { Coupon, MerchantInfo } from '../../../shared/types/coupons';
+import { PATHS } from '../../../../../routes/paths';
 import { DealCard } from './DealCard';
 import { ImageWithFallback } from './ImageWithFallback';
 
@@ -72,6 +74,7 @@ const mapStore = (raw: BackendStore): StoreDetail => {
 };
 
 export function RestaurantDetail({ storeId, onBack }: RestaurantDetailProps) {
+  const navigate = useNavigate();
   const [activeTab, setActiveTab] = useState<'deals' | 'menu' | 'reviews'>('deals');
   const [store, setStore] = useState<StoreDetail>(FALLBACK_STORE);
   const [coupons, setCoupons] = useState<Coupon[]>([]);
@@ -131,6 +134,20 @@ export function RestaurantDetail({ storeId, onBack }: RestaurantDetailProps) {
     phone: store.phone,
   };
 
+  const handleWriteReview = () => {
+    if (!store.id || !store.merchantId) {
+      return;
+    }
+
+    navigate(PATHS.CUSTOMER.WRITE_REVIEW, {
+      state: {
+        merchantId: store.merchantId,
+        merchantName: store.name,
+        storeId: store.id,
+      },
+    });
+  };
+
   return (
     <div className="min-h-screen bg-white pb-20">
       <div className="relative h-64 w-full">
@@ -168,6 +185,17 @@ export function RestaurantDetail({ storeId, onBack }: RestaurantDetailProps) {
             <span className="font-semibold">{store.rating.toFixed(1)}</span>
           </div>
           <span className="text-sm text-gray-500">{store.reviewCount} reviews</span>
+        </div>
+
+        <div className="mt-4 flex justify-center">
+          <button
+            type="button"
+            onClick={handleWriteReview}
+            disabled={!store.id || !store.merchantId}
+            className="rounded-full bg-[#990000] px-5 py-2.5 text-sm font-semibold text-white shadow transition hover:bg-[#7a0000] disabled:cursor-not-allowed disabled:bg-gray-300"
+          >
+            Write Review
+          </button>
         </div>
 
         <div className="mt-6 space-y-3 rounded-3xl border border-gray-100 bg-gray-50 p-5">

--- a/src/features/customer/pages/MerchantDetailPage/components/__tests__/RestaurantDetail.test.tsx
+++ b/src/features/customer/pages/MerchantDetailPage/components/__tests__/RestaurantDetail.test.tsx
@@ -1,0 +1,81 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
+import { PATHS } from '../../../../../../routes/paths';
+
+const { apiGetMock, getAvailableCouponsMock, navigateMock } = vi.hoisted(() => ({
+  apiGetMock: vi.fn(),
+  getAvailableCouponsMock: vi.fn(),
+  navigateMock: vi.fn(),
+}));
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => navigateMock,
+  };
+});
+
+vi.mock('../../../../../../api/apiClient', () => ({
+  apiClient: {
+    get: apiGetMock,
+  },
+}));
+
+vi.mock('../../../../shared/services/couponService', () => ({
+  couponService: {
+    getAvailableCoupons: getAvailableCouponsMock,
+  },
+}));
+
+describe('RestaurantDetail', () => {
+  beforeEach(() => {
+    apiGetMock.mockReset();
+    getAvailableCouponsMock.mockReset();
+    navigateMock.mockReset();
+    apiGetMock.mockResolvedValue({
+      data: {
+        data: {
+          id: 235,
+          merchant_id: 205,
+          name: 'Revieu Demo Cafe',
+          description: 'Seeded store for frontend/backend integration testing',
+          address: '123 Integration Ave',
+          city: 'San Francisco',
+          state: 'CA',
+          country: 'USA',
+          phone: '(415) 555-0101',
+          avg_rating: 0,
+          review_count: 0,
+        },
+      },
+    });
+    getAvailableCouponsMock.mockResolvedValue([]);
+  });
+
+  it('navigates to write review with store and merchant context', async () => {
+    const { RestaurantDetail } = await import('../RestaurantDetail');
+
+    render(
+      <MemoryRouter>
+        <RestaurantDetail storeId="235" />
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Revieu Demo Cafe')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /write review/i }));
+
+    expect(navigateMock).toHaveBeenCalledWith(PATHS.CUSTOMER.WRITE_REVIEW, {
+      state: {
+        merchantId: '205',
+        merchantName: 'Revieu Demo Cafe',
+        storeId: '235',
+      },
+    });
+  });
+});

--- a/src/features/customer/profile/components/PendingReviewMerchants.tsx
+++ b/src/features/customer/profile/components/PendingReviewMerchants.tsx
@@ -37,7 +37,7 @@ export const PendingReviewMerchants: React.FC<PendingReviewMerchantsProps> = ({
         <div className="grid grid-cols-1 md:grid-cols-2 gap-5">
           {merchants.map((merchant) => (
             <article
-              key={merchant.id}
+              key={merchant.storeId}
               className="relative overflow-hidden rounded-[24px] border border-gray-100 bg-white p-5 shadow-[0_8px_28px_-14px_rgba(17,24,39,0.2)] transition-all hover:-translate-y-0.5 hover:shadow-[0_14px_34px_-14px_rgba(17,24,39,0.35)]"
             >
               <div className="absolute -top-10 -right-6 h-24 w-24 rounded-full bg-brand-red/8 blur-2xl" />

--- a/src/features/customer/profile/components/__tests__/PendingReviewMerchants.test.tsx
+++ b/src/features/customer/profile/components/__tests__/PendingReviewMerchants.test.tsx
@@ -8,14 +8,16 @@ describe('PendingReviewMerchants', () => {
   it('renders Laet Merchant I Visit cards and handles write review action', () => {
     const merchants: PendingReviewMerchant[] = [
       {
-        id: 'm1',
+        merchantId: '205',
+        storeId: 'm1',
         businessName: 'Sushirrito',
         businessImage: 'https://picsum.photos/id/292/100/100',
         lastVisitedAt: 'Yesterday',
         lastOrderItems: ['Sumo Crunch', 'Lava Nachos'],
       },
       {
-        id: 'm2',
+        merchantId: '206',
+        storeId: 'm2',
         businessName: 'Philz Coffee',
         businessImage: 'https://picsum.photos/id/431/100/100',
         lastVisitedAt: 'Jan 22',

--- a/src/features/customer/profile/pages/ProfilePage.tsx
+++ b/src/features/customer/profile/pages/ProfilePage.tsx
@@ -204,8 +204,9 @@ const ProfilePage: React.FC = () => {
   const handleWriteReviewFromMerchant = (merchant: PendingReviewMerchant) => {
     navigate(PATHS.CUSTOMER.WRITE_REVIEW, {
       state: {
-        merchantId: merchant.id,
+        merchantId: merchant.merchantId,
         merchantName: merchant.businessName,
+        storeId: merchant.storeId,
       },
     });
   };

--- a/src/features/customer/profile/pages/__tests__/ProfilePage.test.tsx
+++ b/src/features/customer/profile/pages/__tests__/ProfilePage.test.tsx
@@ -3,13 +3,23 @@ import '@testing-library/jest-dom/vitest';
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 import { MemoryRouter } from 'react-router-dom';
 import type { ReactNode, SVGProps } from 'react';
+import { PATHS } from '../../../../../routes/paths';
 
-const { reviewsListMock, pendingMerchantsMock, userVouchersMock, logoutMock } = vi.hoisted(() => ({
+const { reviewsListMock, pendingMerchantsMock, userVouchersMock, logoutMock, navigateMock } = vi.hoisted(() => ({
   reviewsListMock: vi.fn(),
   pendingMerchantsMock: vi.fn(),
   userVouchersMock: vi.fn(),
   logoutMock: vi.fn(),
+  navigateMock: vi.fn(),
 }));
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => navigateMock,
+  };
+});
 
 function DummyIcon(props: SVGProps<SVGSVGElement>) {
   return <svg data-testid="icon" {...props} />;
@@ -41,7 +51,31 @@ vi.mock('../../components', () => ({
     </div>
   ),
   AccountSection: () => <div>account</div>,
-  PendingReviewMerchants: () => <div>pending</div>,
+  PendingReviewMerchants: ({
+    merchants,
+    onWriteReview,
+  }: {
+    merchants: Array<{
+      merchantId: string;
+      storeId: string;
+      businessName: string;
+      businessImage: string;
+      lastVisitedAt: string;
+      lastOrderItems: string[];
+    }>;
+    onWriteReview: (merchant: {
+      merchantId: string;
+      storeId: string;
+      businessName: string;
+      businessImage: string;
+      lastVisitedAt: string;
+      lastOrderItems: string[];
+    }) => void;
+  }) => (
+    merchants.length > 0
+      ? <button onClick={() => onWriteReview(merchants[0])}>Write pending review</button>
+      : <div>pending</div>
+  ),
   MyHistorySection: ({ onViewAllReviews }: { onViewAllReviews: () => void }) => (
     <button onClick={onViewAllReviews}>View all reviews</button>
   ),
@@ -82,6 +116,7 @@ describe('ProfilePage', () => {
     pendingMerchantsMock.mockReset();
     userVouchersMock.mockReset();
     logoutMock.mockReset();
+    navigateMock.mockReset();
     pendingMerchantsMock.mockResolvedValue([]);
     userVouchersMock.mockResolvedValue({
       active: [],
@@ -202,5 +237,40 @@ describe('ProfilePage', () => {
 
     expect(screen.getByText('1 Available')).toBeInTheDocument();
     expect(screen.getAllByText('coupon')).toHaveLength(1);
+  });
+
+  it('navigates to write review with merchant and store context from pending reviews', async () => {
+    reviewsListMock.mockResolvedValue({
+      data: [],
+      total: 0,
+    });
+    pendingMerchantsMock.mockResolvedValue([
+      {
+        merchantId: '205',
+        storeId: '235',
+        businessName: 'Revieu Demo Cafe',
+        businessImage: 'https://example.com/store.jpg',
+        lastVisitedAt: 'Today',
+        lastOrderItems: ['Paid Demo Bundle'],
+      },
+    ]);
+
+    const { default: ProfilePage } = await import('../ProfilePage');
+
+    render(
+      <MemoryRouter>
+        <ProfilePage />
+      </MemoryRouter>
+    );
+
+    fireEvent.click(await screen.findByRole('button', { name: /write pending review/i }));
+
+    expect(navigateMock).toHaveBeenCalledWith(PATHS.CUSTOMER.WRITE_REVIEW, {
+      state: {
+        merchantId: '205',
+        merchantName: 'Revieu Demo Cafe',
+        storeId: '235',
+      },
+    });
   });
 });

--- a/src/features/customer/profile/services/__tests__/profileService.test.ts
+++ b/src/features/customer/profile/services/__tests__/profileService.test.ts
@@ -78,7 +78,8 @@ describe('profileService', () => {
     expect(listStoresMock).toHaveBeenCalledWith(100);
     expect(merchants).toEqual([
       expect.objectContaining({
-        id: '235',
+        merchantId: '205',
+        storeId: '235',
         businessName: 'Revieu Demo Cafe',
         businessImage: 'https://example.com/store.jpg',
         lastOrderItems: ['Paid Demo Bundle'],

--- a/src/features/customer/profile/services/profileService.ts
+++ b/src/features/customer/profile/services/profileService.ts
@@ -100,9 +100,9 @@ async function fetchPendingReviewMerchantsFromApi(): Promise<PendingReviewMercha
     const storeId =
       order.store_id !== null && order.store_id !== undefined
         ? String(order.store_id)
-        : merchantId;
+        : '';
 
-    if (!storeId || latestPendingByStore.has(storeId)) {
+    if (!merchantId || !storeId || latestPendingByStore.has(storeId)) {
       return;
     }
 
@@ -112,7 +112,8 @@ async function fetchPendingReviewMerchantsFromApi(): Promise<PendingReviewMercha
 
     const store = storeById.get(storeId);
     latestPendingByStore.set(storeId, {
-      id: storeId,
+      merchantId,
+      storeId,
       businessName: store?.name || `Merchant ${merchantId || storeId}`,
       businessImage: store?.image || DEFAULT_BUSINESS_IMAGE,
       lastVisitedAt: formatLastVisitedAt(order.created_at),

--- a/src/features/customer/profile/types/index.ts
+++ b/src/features/customer/profile/types/index.ts
@@ -59,7 +59,8 @@ export interface Order {
 }
 
 export interface PendingReviewMerchant {
-  id: string;
+  merchantId: string;
+  storeId: string;
   businessName: string;
   businessImage: string;
   lastVisitedAt: string;

--- a/src/features/customer/reviews/contexts/ReviewContext.tsx
+++ b/src/features/customer/reviews/contexts/ReviewContext.tsx
@@ -951,14 +951,35 @@ export const ReviewProvider: React.FC<ReviewProviderProps> = ({
       dispatch({ type: 'CLEAR_SUBMIT_ERROR' });
 
       try {
+        const merchantId = state.reviewData.merchantId?.trim();
+        const storeId = state.reviewData.storeId?.trim();
+
+        if (!merchantId) {
+          dispatch({ type: 'SET_SUBMITTING', payload: false });
+          dispatch({
+            type: 'SET_SUBMIT_ERROR',
+            payload: 'Merchant context is missing. Please start your review from a merchant page.',
+          });
+          return false;
+        }
+
+        if (!storeId) {
+          dispatch({ type: 'SET_SUBMITTING', payload: false });
+          dispatch({
+            type: 'SET_SUBMIT_ERROR',
+            payload: 'Store context is missing. Please start your review from a merchant page.',
+          });
+          return false;
+        }
+
         // Use provided URLs or get from state
         const imageUrls = uploadedImageUrls ?? state.reviewData.images
           ?.filter(img => img.uploadState.status === 'complete' && img.fileUrl)
           .map(img => img.fileUrl!) ?? [];
 
         const request: CreateReviewRequest = {
-          merchantId: state.reviewData.merchantId || '',
-          storeId: state.reviewData.storeId || state.reviewData.venueId || undefined,
+          merchantId,
+          storeId,
           overallRating: state.reviewData.overallRating || 0,
           detailedRatings: state.reviewData.detailedRatings,
           text: state.reviewData.reviewText,

--- a/src/features/customer/reviews/contexts/__tests__/ReviewContextSubmit.test.tsx
+++ b/src/features/customer/reviews/contexts/__tests__/ReviewContextSubmit.test.tsx
@@ -1,0 +1,61 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ReviewProvider, useReviewContext } from '../ReviewContext';
+
+const { createReviewMock } = vi.hoisted(() => ({
+  createReviewMock: vi.fn(),
+}));
+
+vi.mock('../../../../../api/reviews', () => ({
+  reviewsApi: {
+    create: createReviewMock,
+  },
+}));
+
+vi.mock('../../services/gemini', () => ({
+  generateReviewSuggestions: vi.fn(),
+}));
+
+vi.mock('../../../../../api/media', () => ({
+  mediaApi: {
+    getUploadUrls: vi.fn(),
+  },
+  uploadToR2: vi.fn(),
+}));
+
+const SubmitHarness = () => {
+  const { actions, state } = useReviewContext();
+
+  return (
+    <div>
+      <button type="button" onClick={() => void actions.submitReview()}>
+        Submit
+      </button>
+      {state.submitError ? <span>{state.submitError}</span> : null}
+    </div>
+  );
+};
+
+describe('ReviewContext submitReview', () => {
+  beforeEach(() => {
+    createReviewMock.mockReset();
+    createReviewMock.mockResolvedValue({ id: '14' });
+  });
+
+  it('blocks submission when store context is missing', async () => {
+    render(
+      <ReviewProvider merchantId="205">
+        <SubmitHarness />
+      </ReviewProvider>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /submit/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/store context is missing/i)).toBeInTheDocument();
+    });
+
+    expect(createReviewMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/features/customer/reviews/index.ts
+++ b/src/features/customer/reviews/index.ts
@@ -1,5 +1,6 @@
 export { default as ReviewsPage } from './pages/ReviewsPage';
 export { default as WriteReviewPage } from './pages/WriteReviewPage';
+export { default as WriteReviewSelectPage } from './pages/WriteReviewSelectPage';
 export { default as PostPage } from './pages/PostPage';
 export { default as ReviewSuccessPage } from './pages/ReviewSuccessPage';
 export * from './contexts/ReviewContext';

--- a/src/features/customer/reviews/pages/ReviewSuccessPage.tsx
+++ b/src/features/customer/reviews/pages/ReviewSuccessPage.tsx
@@ -46,7 +46,7 @@ const ReviewSuccessPage: React.FC = () => {
             Back to Home
           </button>
           <button
-            onClick={() => navigate(PATHS.CUSTOMER.WRITE_REVIEW)}
+            onClick={() => navigate(PATHS.CUSTOMER.WRITE_REVIEW_SELECT)}
             className="w-full flex items-center justify-center gap-2 py-4 bg-white border border-gray-200 text-gray-700 rounded-xl font-medium hover:bg-gray-50 transition-all"
           >
             <PenLine className="w-5 h-5" />

--- a/src/features/customer/reviews/pages/WriteReviewSelectPage.tsx
+++ b/src/features/customer/reviews/pages/WriteReviewSelectPage.tsx
@@ -1,0 +1,310 @@
+import React, { useEffect, useState } from 'react';
+import { ArrowLeft, ChevronRight, MapPin, Search, Store } from 'lucide-react';
+import { useNavigate } from 'react-router-dom';
+import { ImageWithFallback } from '../../../../components/common';
+import { PATHS } from '../../../../routes/paths';
+import {
+  getWriteReviewTargetSelectionData,
+  ReviewMerchantTargetOption,
+  ReviewStoreTargetOption,
+  WriteReviewTargetSelectionData,
+} from '../services/writeReviewTargetService';
+
+const matchesMerchantSearch = (merchant: ReviewMerchantTargetOption, search: string): boolean => {
+  const haystack = `${merchant.name} ${merchant.category}`.toLowerCase();
+  return haystack.includes(search);
+};
+
+const MerchantListSection = ({
+  title,
+  merchants,
+  onSelect,
+}: {
+  title: string;
+  merchants: ReviewMerchantTargetOption[];
+  onSelect: (merchant: ReviewMerchantTargetOption) => void;
+}) => {
+  if (merchants.length === 0) {
+    return null;
+  }
+
+  return (
+    <section className="space-y-3">
+      <h2 className="text-sm font-semibold uppercase tracking-[0.16em] text-gray-400">{title}</h2>
+      <div className="space-y-3">
+        {merchants.map((merchant) => (
+          <button
+            key={merchant.merchantId}
+            type="button"
+            onClick={() => onSelect(merchant)}
+            className="flex w-full items-center gap-3 rounded-3xl border border-gray-100 bg-white p-4 text-left shadow-sm transition hover:border-[#990000]/20 hover:shadow-md"
+          >
+            <ImageWithFallback
+              src={merchant.image}
+              alt={merchant.name}
+              className="h-14 w-14 rounded-2xl object-cover"
+            />
+            <div className="min-w-0 flex-1">
+              <p className="truncate text-base font-semibold text-gray-900">{merchant.name}</p>
+              <p className="mt-1 text-sm text-gray-500">{merchant.category}</p>
+            </div>
+            <div className="text-right">
+              <p className="text-sm font-semibold text-[#990000]">{merchant.rating.toFixed(1)}</p>
+              <p className="text-xs text-gray-400">{merchant.reviewCount} reviews</p>
+            </div>
+            <ChevronRight className="h-5 w-5 text-gray-300" />
+          </button>
+        ))}
+      </div>
+    </section>
+  );
+};
+
+const StoreListSection = ({
+  title,
+  stores,
+  onSelect,
+}: {
+  title: string;
+  stores: ReviewStoreTargetOption[];
+  onSelect: (store: ReviewStoreTargetOption) => void;
+}) => {
+  if (stores.length === 0) {
+    return null;
+  }
+
+  return (
+    <section className="space-y-3">
+      <h2 className="text-sm font-semibold uppercase tracking-[0.16em] text-gray-400">{title}</h2>
+      <div className="space-y-3">
+        {stores.map((store) => (
+          <button
+            key={store.storeId}
+            type="button"
+            onClick={() => onSelect(store)}
+            className="flex w-full items-center gap-3 rounded-3xl border border-gray-100 bg-white p-4 text-left shadow-sm transition hover:border-[#990000]/20 hover:shadow-md"
+          >
+            <ImageWithFallback
+              src={store.image}
+              alt={store.name}
+              className="h-14 w-14 rounded-2xl object-cover"
+            />
+            <div className="min-w-0 flex-1">
+              <p className="truncate text-base font-semibold text-gray-900">{store.name}</p>
+              <div className="mt-1 flex items-center gap-1 text-sm text-gray-500">
+                <MapPin className="h-3.5 w-3.5" />
+                <span className="truncate">{store.address}</span>
+              </div>
+            </div>
+            <div className="text-right">
+              <p className="text-sm font-semibold text-[#990000]">{store.rating.toFixed(1)}</p>
+              <p className="text-xs text-gray-400">{store.reviewCount} reviews</p>
+            </div>
+            <ChevronRight className="h-5 w-5 text-gray-300" />
+          </button>
+        ))}
+      </div>
+    </section>
+  );
+};
+
+const WriteReviewSelectPage: React.FC = () => {
+  const navigate = useNavigate();
+  const [selectionData, setSelectionData] = useState<WriteReviewTargetSelectionData | null>(null);
+  const [selectedMerchant, setSelectedMerchant] = useState<ReviewMerchantTargetOption | null>(null);
+  const [merchantSearch, setMerchantSearch] = useState('');
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const loadSelectionData = async () => {
+      setIsLoading(true);
+      setError(null);
+
+      try {
+        const nextData = await getWriteReviewTargetSelectionData();
+        if (!cancelled) {
+          setSelectionData(nextData);
+        }
+      } catch (loadError) {
+        if (!cancelled) {
+          console.error('Failed to load review target selector data:', loadError);
+          setError('Unable to load merchants right now.');
+        }
+      } finally {
+        if (!cancelled) {
+          setIsLoading(false);
+        }
+      }
+    };
+
+    void loadSelectionData();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const normalizedMerchantSearch = merchantSearch.trim().toLowerCase();
+  const recentMerchants = selectionData?.recentMerchants ?? [];
+  const otherMerchants = selectionData?.otherMerchants ?? [];
+  const filteredRecentMerchants = normalizedMerchantSearch
+    ? recentMerchants.filter((merchant) => matchesMerchantSearch(merchant, normalizedMerchantSearch))
+    : recentMerchants;
+  const filteredOtherMerchants = normalizedMerchantSearch
+    ? otherMerchants.filter((merchant) => matchesMerchantSearch(merchant, normalizedMerchantSearch))
+    : otherMerchants;
+
+  const selectedStores = selectedMerchant
+    ? selectionData?.storesByMerchant[selectedMerchant.merchantId] ?? []
+    : [];
+  const recentStores = selectedStores.filter((store) => store.isRecent);
+  const otherStores = selectedStores.filter((store) => !store.isRecent);
+
+  const handleSelectStore = (store: ReviewStoreTargetOption) => {
+    if (!selectedMerchant) {
+      return;
+    }
+
+    navigate(PATHS.CUSTOMER.WRITE_REVIEW, {
+      state: {
+        merchantId: selectedMerchant.merchantId,
+        merchantName: selectedMerchant.name,
+        storeId: store.storeId,
+      },
+    });
+  };
+
+  return (
+    <div className="min-h-screen bg-[#f8f6f3]">
+      <div className="mx-auto flex min-h-screen max-w-2xl flex-col px-4 pb-8 pt-6">
+        <div className="mb-6 flex items-center gap-3">
+          <button
+            type="button"
+            onClick={() => {
+              if (selectedMerchant) {
+                setSelectedMerchant(null);
+                return;
+              }
+
+              navigate(-1);
+            }}
+            className="flex h-11 w-11 items-center justify-center rounded-full bg-white text-gray-700 shadow-sm"
+            aria-label="Go back"
+          >
+            <ArrowLeft className="h-5 w-5" />
+          </button>
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-[0.18em] text-[#990000]">
+              {selectedMerchant ? 'Step 2 of 2' : 'Step 1 of 2'}
+            </p>
+            <h1 className="text-2xl font-bold text-gray-900">
+              {selectedMerchant ? 'Choose a location' : 'Choose a merchant'}
+            </h1>
+          </div>
+        </div>
+
+        {!selectedMerchant && (
+          <div className="mb-6 rounded-3xl border border-gray-100 bg-white p-4 shadow-sm">
+            <label className="mb-2 block text-sm font-medium text-gray-600" htmlFor="merchant-search">
+              Search merchants
+            </label>
+            <div className="flex items-center gap-3 rounded-2xl border border-gray-200 bg-gray-50 px-4 py-3">
+              <Search className="h-4 w-4 text-gray-400" />
+              <input
+                id="merchant-search"
+                value={merchantSearch}
+                onChange={(event) => setMerchantSearch(event.target.value)}
+                placeholder="Search merchants"
+                className="w-full bg-transparent text-sm text-gray-900 outline-none placeholder:text-gray-400"
+              />
+            </div>
+          </div>
+        )}
+
+        {isLoading && (
+          <div className="rounded-3xl border border-gray-100 bg-white px-5 py-8 text-center text-sm text-gray-500 shadow-sm">
+            Loading review options...
+          </div>
+        )}
+
+        {error && !isLoading && (
+          <div className="rounded-3xl border border-red-100 bg-red-50 px-5 py-8 text-center text-sm text-red-700 shadow-sm">
+            {error}
+          </div>
+        )}
+
+        {!isLoading && !error && !selectedMerchant && (
+          <div className="space-y-6">
+            {normalizedMerchantSearch ? (
+              filteredRecentMerchants.length === 0 && filteredOtherMerchants.length === 0 ? (
+                <div className="rounded-3xl border border-dashed border-gray-200 bg-white px-5 py-8 text-center text-sm text-gray-500 shadow-sm">
+                  No merchants match your search.
+                </div>
+              ) : (
+                <MerchantListSection
+                  title="Search results"
+                  merchants={[...filteredRecentMerchants, ...filteredOtherMerchants]}
+                  onSelect={setSelectedMerchant}
+                />
+              )
+            ) : (
+              <>
+                <MerchantListSection
+                  title="Recent purchases"
+                  merchants={filteredRecentMerchants}
+                  onSelect={setSelectedMerchant}
+                />
+                <MerchantListSection
+                  title="All merchants"
+                  merchants={filteredOtherMerchants}
+                  onSelect={setSelectedMerchant}
+                />
+              </>
+            )}
+          </div>
+        )}
+
+        {!isLoading && !error && selectedMerchant && (
+          <div className="space-y-6">
+            <div className="rounded-3xl border border-gray-100 bg-white p-4 shadow-sm">
+              <div className="flex items-center gap-3">
+                <ImageWithFallback
+                  src={selectedMerchant.image}
+                  alt={selectedMerchant.name}
+                  className="h-14 w-14 rounded-2xl object-cover"
+                />
+                <div className="min-w-0">
+                  <p className="truncate text-lg font-semibold text-gray-900">{selectedMerchant.name}</p>
+                  <p className="text-sm text-gray-500">{selectedMerchant.category}</p>
+                </div>
+              </div>
+            </div>
+
+            {selectedStores.length === 0 ? (
+              <div className="rounded-3xl border border-dashed border-gray-200 bg-white px-5 py-8 text-center text-sm text-gray-500 shadow-sm">
+                This merchant does not have any published locations available for review.
+              </div>
+            ) : (
+              <>
+                <StoreListSection title="Recent purchases" stores={recentStores} onSelect={handleSelectStore} />
+                <StoreListSection title="All locations" stores={otherStores} onSelect={handleSelectStore} />
+              </>
+            )}
+          </div>
+        )}
+
+        {!isLoading && !error && !selectedMerchant && recentMerchants.length === 0 && otherMerchants.length === 0 && (
+          <div className="rounded-3xl border border-dashed border-gray-200 bg-white px-5 py-8 text-center text-sm text-gray-500 shadow-sm">
+            <Store className="mx-auto mb-3 h-8 w-8 text-gray-300" />
+            No merchants with reviewable locations are available right now.
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default WriteReviewSelectPage;

--- a/src/features/customer/reviews/pages/__tests__/WriteReviewSelectPage.test.tsx
+++ b/src/features/customer/reviews/pages/__tests__/WriteReviewSelectPage.test.tsx
@@ -1,0 +1,141 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
+import { PATHS } from '../../../../../routes/paths';
+
+const { navigateMock, getSelectionDataMock } = vi.hoisted(() => ({
+  navigateMock: vi.fn(),
+  getSelectionDataMock: vi.fn(),
+}));
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => navigateMock,
+  };
+});
+
+vi.mock('../../services/writeReviewTargetService', () => ({
+  getWriteReviewTargetSelectionData: getSelectionDataMock,
+}));
+
+describe('WriteReviewSelectPage', () => {
+  beforeEach(() => {
+    navigateMock.mockReset();
+    getSelectionDataMock.mockReset();
+    getSelectionDataMock.mockResolvedValue({
+      recentMerchants: [
+        {
+          merchantId: '205',
+          name: 'Revieu Demo Cafe',
+          category: 'Cafe',
+          image: 'https://example.com/205.jpg',
+          rating: 4.6,
+          reviewCount: 8,
+        },
+      ],
+      otherMerchants: [
+        {
+          merchantId: '206',
+          name: 'Mission Street Ramen',
+          category: 'Ramen',
+          image: 'https://example.com/206.jpg',
+          rating: 4.8,
+          reviewCount: 12,
+        },
+      ],
+      storesByMerchant: {
+        '205': [
+          {
+            storeId: '235',
+            merchantId: '205',
+            name: 'Revieu Demo Cafe - Main',
+            image: 'https://example.com/store-235.jpg',
+            category: 'Cafe',
+            address: '123 Integration Ave, San Francisco, CA',
+            rating: 4.6,
+            reviewCount: 8,
+            isRecent: true,
+          },
+          {
+            storeId: '236',
+            merchantId: '205',
+            name: 'Revieu Demo Cafe - Annex',
+            image: 'https://example.com/store-236.jpg',
+            category: 'Cafe',
+            address: '234 Integration Ave, San Francisco, CA',
+            rating: 4.2,
+            reviewCount: 3,
+            isRecent: false,
+          },
+        ],
+        '206': [
+          {
+            storeId: '277',
+            merchantId: '206',
+            name: 'Mission Street Ramen',
+            image: 'https://example.com/store-277.jpg',
+            category: 'Ramen',
+            address: '777 Mission St, San Francisco, CA',
+            rating: 4.8,
+            reviewCount: 12,
+            isRecent: false,
+          },
+        ],
+      },
+    });
+  });
+
+  it('filters all merchants by search', async () => {
+    const { default: WriteReviewSelectPage } = await import('../WriteReviewSelectPage');
+
+    render(
+      <MemoryRouter>
+        <WriteReviewSelectPage />
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(/choose a merchant/i)).toBeInTheDocument();
+    });
+
+    fireEvent.change(screen.getByPlaceholderText(/search merchants/i), {
+      target: { value: 'ramen' },
+    });
+
+    expect(screen.queryByText('Revieu Demo Cafe')).not.toBeInTheDocument();
+    expect(screen.getByText('Mission Street Ramen')).toBeInTheDocument();
+  });
+
+  it('navigates to write review after choosing merchant and store', async () => {
+    const { default: WriteReviewSelectPage } = await import('../WriteReviewSelectPage');
+
+    render(
+      <MemoryRouter>
+        <WriteReviewSelectPage />
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Revieu Demo Cafe')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /revieu demo cafe/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/choose a location/i)).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /revieu demo cafe - main/i }));
+
+    expect(navigateMock).toHaveBeenCalledWith(PATHS.CUSTOMER.WRITE_REVIEW, {
+      state: {
+        merchantId: '205',
+        merchantName: 'Revieu Demo Cafe',
+        storeId: '235',
+      },
+    });
+  });
+});

--- a/src/features/customer/reviews/pages/index.ts
+++ b/src/features/customer/reviews/pages/index.ts
@@ -1,4 +1,5 @@
 export { default as ReviewsPage } from './ReviewsPage';
 export { default as WriteReviewPage } from './WriteReviewPage';
+export { default as WriteReviewSelectPage } from './WriteReviewSelectPage';
 export { default as PostPage } from './PostPage';
 export { default as ReviewSuccessPage } from './ReviewSuccessPage';

--- a/src/features/customer/reviews/services/__tests__/writeReviewTargetService.test.ts
+++ b/src/features/customer/reviews/services/__tests__/writeReviewTargetService.test.ts
@@ -1,0 +1,184 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockGet, listStoresMock } = vi.hoisted(() => ({
+  mockGet: vi.fn(),
+  listStoresMock: vi.fn(),
+}));
+
+vi.mock('../../../../../api/apiClient', () => ({
+  apiClient: {
+    get: mockGet,
+  },
+}));
+
+vi.mock('../../../shared/services/storeBrowserService', () => ({
+  storeBrowserService: {
+    listStores: listStoresMock,
+  },
+}));
+
+import { getWriteReviewTargetSelectionData } from '../writeReviewTargetService';
+
+describe('writeReviewTargetService', () => {
+  beforeEach(() => {
+    mockGet.mockReset();
+    listStoresMock.mockReset();
+  });
+
+  it('puts recently purchased merchants first and sorts stores by recent purchases within a merchant', async () => {
+    mockGet.mockImplementation((url: string) => {
+      if (url === '/orders') {
+        return Promise.resolve({
+          data: {
+            data: [
+              {
+                id: 10,
+                merchant_id: 205,
+                store_id: 235,
+                status: 'paid',
+                created_at: '2026-04-18T09:00:00Z',
+              },
+              {
+                id: 9,
+                merchant_id: 205,
+                store_id: 236,
+                status: 'paid',
+                created_at: '2026-04-17T09:00:00Z',
+              },
+              {
+                id: 8,
+                merchant_id: 206,
+                store_id: 277,
+                status: 'paid',
+                created_at: '2026-04-16T09:00:00Z',
+              },
+            ],
+          },
+        });
+      }
+
+      if (url === '/merchants') {
+        return Promise.resolve({
+          data: {
+            data: [
+              {
+                id: '205',
+                name: 'Revieu Demo Cafe',
+                businessName: 'Revieu Demo Cafe',
+                category: 'Cafe',
+                rating: 4.6,
+                reviewCount: 8,
+                coverImage: 'https://example.com/205.jpg',
+              },
+              {
+                id: '206',
+                name: 'Mission Street Ramen',
+                businessName: 'Mission Street Ramen',
+                category: 'Ramen',
+                rating: 4.8,
+                reviewCount: 12,
+                coverImage: 'https://example.com/206.jpg',
+              },
+              {
+                id: '207',
+                name: 'Sunset Boba',
+                businessName: 'Sunset Boba',
+                category: 'Drinks',
+                rating: 4.3,
+                reviewCount: 4,
+                coverImage: 'https://example.com/207.jpg',
+              },
+            ],
+          },
+        });
+      }
+
+      throw new Error(`Unexpected GET ${url}`);
+    });
+
+    listStoresMock.mockResolvedValue([
+      {
+        id: '235',
+        merchantId: '205',
+        name: 'Revieu Demo Cafe - Main',
+        image: 'https://example.com/store-235.jpg',
+        category: 'Cafe',
+        description: '',
+        rating: 4.6,
+        reviewCount: 8,
+        distanceMiles: 0.5,
+        distanceLabel: '0.5 mi',
+        isOpen: true,
+        city: 'San Francisco',
+        state: 'CA',
+      },
+      {
+        id: '236',
+        merchantId: '205',
+        name: 'Revieu Demo Cafe - Annex',
+        image: 'https://example.com/store-236.jpg',
+        category: 'Cafe',
+        description: '',
+        rating: 4.2,
+        reviewCount: 3,
+        distanceMiles: 0.8,
+        distanceLabel: '0.8 mi',
+        isOpen: true,
+        city: 'San Francisco',
+        state: 'CA',
+      },
+      {
+        id: '237',
+        merchantId: '205',
+        name: 'Revieu Demo Cafe - Uptown',
+        image: 'https://example.com/store-237.jpg',
+        category: 'Cafe',
+        description: '',
+        rating: 4.1,
+        reviewCount: 1,
+        distanceMiles: 1.2,
+        distanceLabel: '1.2 mi',
+        isOpen: true,
+        city: 'San Francisco',
+        state: 'CA',
+      },
+      {
+        id: '277',
+        merchantId: '206',
+        name: 'Mission Street Ramen',
+        image: 'https://example.com/store-277.jpg',
+        category: 'Ramen',
+        description: '',
+        rating: 4.8,
+        reviewCount: 12,
+        distanceMiles: 0.7,
+        distanceLabel: '0.7 mi',
+        isOpen: true,
+        city: 'San Francisco',
+        state: 'CA',
+      },
+      {
+        id: '278',
+        merchantId: '207',
+        name: 'Sunset Boba - USC',
+        image: 'https://example.com/store-278.jpg',
+        category: 'Drinks',
+        description: '',
+        rating: 4.3,
+        reviewCount: 4,
+        distanceMiles: 1.1,
+        distanceLabel: '1.1 mi',
+        isOpen: true,
+        city: 'Los Angeles',
+        state: 'CA',
+      },
+    ]);
+
+    const result = await getWriteReviewTargetSelectionData();
+
+    expect(result.recentMerchants.map((merchant) => merchant.merchantId)).toEqual(['205', '206']);
+    expect(result.otherMerchants.map((merchant) => merchant.merchantId)).toEqual(['207']);
+    expect(result.storesByMerchant['205'].map((store) => store.storeId)).toEqual(['235', '236', '237']);
+    expect(result.storesByMerchant['205'].map((store) => store.isRecent)).toEqual([true, true, false]);
+  });
+});

--- a/src/features/customer/reviews/services/writeReviewTargetService.ts
+++ b/src/features/customer/reviews/services/writeReviewTargetService.ts
@@ -1,0 +1,173 @@
+import { apiClient } from '../../../../api/apiClient';
+import { storeBrowserService, StoreBrowserMerchant } from '../../shared/services/storeBrowserService';
+
+type BackendOrder = {
+  merchant_id?: number | string | null;
+  store_id?: number | string | null;
+  status?: string | null;
+  created_at?: string | null;
+};
+
+type BackendMerchant = {
+  id: number | string;
+  name?: string | null;
+  businessName?: string | null;
+  category?: string | null;
+  rating?: number | null;
+  reviewCount?: number | null;
+  coverImage?: string | null;
+};
+
+const DEFAULT_MERCHANT_IMAGE =
+  'https://images.unsplash.com/photo-1504674900247-0877df9cc836?auto=format&fit=crop&q=80&w=1200';
+
+export interface ReviewMerchantTargetOption {
+  merchantId: string;
+  name: string;
+  category: string;
+  image: string;
+  rating: number;
+  reviewCount: number;
+}
+
+export interface ReviewStoreTargetOption {
+  storeId: string;
+  merchantId: string;
+  name: string;
+  image: string;
+  category: string;
+  address: string;
+  rating: number;
+  reviewCount: number;
+  isRecent: boolean;
+}
+
+export interface WriteReviewTargetSelectionData {
+  recentMerchants: ReviewMerchantTargetOption[];
+  otherMerchants: ReviewMerchantTargetOption[];
+  storesByMerchant: Record<string, ReviewStoreTargetOption[]>;
+}
+
+const parseTimestamp = (value?: string | null): number => {
+  if (!value) {
+    return 0;
+  }
+
+  const parsed = new Date(value).getTime();
+  return Number.isNaN(parsed) ? 0 : parsed;
+};
+
+const mapMerchant = (merchant: BackendMerchant): ReviewMerchantTargetOption => ({
+  merchantId: String(merchant.id),
+  name: merchant.businessName?.trim() || merchant.name?.trim() || `Merchant ${merchant.id}`,
+  category: merchant.category?.trim() || 'Merchant',
+  image: merchant.coverImage?.trim() || DEFAULT_MERCHANT_IMAGE,
+  rating: typeof merchant.rating === 'number' ? merchant.rating : 0,
+  reviewCount: typeof merchant.reviewCount === 'number' ? merchant.reviewCount : 0,
+});
+
+const mapStore = (
+  store: StoreBrowserMerchant,
+  isRecent: boolean,
+): ReviewStoreTargetOption => ({
+  storeId: store.id,
+  merchantId: store.merchantId,
+  name: store.name,
+  image: store.image,
+  category: store.category,
+  address: [store.city, store.state].filter(Boolean).join(', ') || 'Location unavailable',
+  rating: store.rating,
+  reviewCount: store.reviewCount,
+  isRecent,
+});
+
+export async function getWriteReviewTargetSelectionData(): Promise<WriteReviewTargetSelectionData> {
+  const [ordersResponse, merchantsResponse, stores] = await Promise.all([
+    apiClient.get<{ data: BackendOrder[] }>('/orders'),
+    apiClient.get<{ data: BackendMerchant[] }>('/merchants'),
+    storeBrowserService.listStores(100),
+  ]);
+
+  const availableMerchantIds = new Set(stores.map((store) => store.merchantId));
+  const availableStoreIds = new Set(stores.map((store) => store.id));
+
+  const merchants = (merchantsResponse.data?.data ?? [])
+    .map(mapMerchant)
+    .filter((merchant) => availableMerchantIds.has(merchant.merchantId))
+    .sort((left, right) => left.name.localeCompare(right.name));
+
+  const merchantById = new Map(merchants.map((merchant) => [merchant.merchantId, merchant]));
+  const recentMerchantIds: string[] = [];
+  const recentStoreIdsByMerchant = new Map<string, string[]>();
+
+  const paidOrders = [...(ordersResponse.data?.data ?? [])]
+    .filter((order) => order.status === 'paid')
+    .sort((left, right) => parseTimestamp(right.created_at) - parseTimestamp(left.created_at));
+
+  paidOrders.forEach((order) => {
+    const merchantId =
+      order.merchant_id !== null && order.merchant_id !== undefined ? String(order.merchant_id) : '';
+    const storeId =
+      order.store_id !== null && order.store_id !== undefined ? String(order.store_id) : '';
+
+    if (!merchantId || !storeId) {
+      return;
+    }
+
+    if (!availableMerchantIds.has(merchantId) || !availableStoreIds.has(storeId)) {
+      return;
+    }
+
+    if (!recentMerchantIds.includes(merchantId)) {
+      recentMerchantIds.push(merchantId);
+    }
+
+    const recentStoreIds = recentStoreIdsByMerchant.get(merchantId) ?? [];
+    if (!recentStoreIds.includes(storeId)) {
+      recentStoreIds.push(storeId);
+      recentStoreIdsByMerchant.set(merchantId, recentStoreIds);
+    }
+  });
+
+  const recentMerchants = recentMerchantIds
+    .map((merchantId) => merchantById.get(merchantId))
+    .filter((merchant): merchant is ReviewMerchantTargetOption => Boolean(merchant));
+
+  const recentMerchantIdSet = new Set(recentMerchants.map((merchant) => merchant.merchantId));
+  const otherMerchants = merchants.filter((merchant) => !recentMerchantIdSet.has(merchant.merchantId));
+
+  const storesByMerchant: Record<string, ReviewStoreTargetOption[]> = {};
+
+  merchants.forEach((merchant) => {
+    const recentStoreIds = recentStoreIdsByMerchant.get(merchant.merchantId) ?? [];
+    const recentStoreOrder = new Map(recentStoreIds.map((storeId, index) => [storeId, index]));
+
+    storesByMerchant[merchant.merchantId] = stores
+      .filter((store) => store.merchantId === merchant.merchantId)
+      .sort((left, right) => {
+        const leftRecent = recentStoreOrder.has(left.id);
+        const rightRecent = recentStoreOrder.has(right.id);
+
+        if (leftRecent && rightRecent) {
+          return recentStoreOrder.get(left.id)! - recentStoreOrder.get(right.id)!;
+        }
+
+        if (leftRecent) {
+          return -1;
+        }
+
+        if (rightRecent) {
+          return 1;
+        }
+
+        return left.name.localeCompare(right.name);
+      })
+      .map((store) => mapStore(store, recentStoreOrder.has(store.id)));
+  });
+
+  return {
+    recentMerchants,
+    otherMerchants,
+    storesByMerchant,
+  };
+}

--- a/src/features/customer/shared/layout/BottomNav/__tests__/BottomNav.test.tsx
+++ b/src/features/customer/shared/layout/BottomNav/__tests__/BottomNav.test.tsx
@@ -1,8 +1,21 @@
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom/vitest';
 import { describe, expect, it, vi } from 'vitest';
 import { MemoryRouter } from 'react-router-dom';
 import { BottomNav } from '..';
+import { PATHS } from '../../../../../../routes/paths';
+
+const { navigateMock } = vi.hoisted(() => ({
+  navigateMock: vi.fn(),
+}));
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => navigateMock,
+  };
+});
 
 vi.mock('../../../../../../contexts/AuthContext', () => ({
   useAuth: () => ({
@@ -23,5 +36,17 @@ describe('BottomNav', () => {
     expect(screen.getByRole('button', { name: /home/i })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /profile/i })).toBeInTheDocument();
     expect(screen.getAllByRole('button')).toHaveLength(3);
+  });
+
+  it('routes the add review button to the review target selector flow', () => {
+    render(
+      <MemoryRouter initialEntries={['/customer/home']}>
+        <BottomNav />
+      </MemoryRouter>
+    );
+
+    fireEvent.click(screen.getAllByRole('button', { name: /add review/i })[0]);
+
+    expect(navigateMock).toHaveBeenCalledWith(PATHS.CUSTOMER.WRITE_REVIEW_SELECT);
   });
 });

--- a/src/features/customer/shared/layout/BottomNav/index.tsx
+++ b/src/features/customer/shared/layout/BottomNav/index.tsx
@@ -20,7 +20,7 @@ export function BottomNav() {
 
   const handlePostClick = () => {
     if (isAuthenticated) {
-      navigate(PATHS.CUSTOMER.WRITE_REVIEW);
+      navigate(PATHS.CUSTOMER.WRITE_REVIEW_SELECT);
     } else {
       setShowLoginModal(true);
     }

--- a/src/routes/paths.ts
+++ b/src/routes/paths.ts
@@ -24,6 +24,7 @@
         POST: (id: string) => `/customer/post/${id}`,
         POST_DETAIL: '/customer/post/:id',
         WRITE_REVIEW: '/customer/write-review',
+        WRITE_REVIEW_SELECT: '/customer/write-review/select',
         REVIEW_SUCCESS: '/customer/review-success',
         EXPLORE: '/customer/explore',
         MERCHANT_INFO: (id: string) => `/customer/merchant/${id}`,


### PR DESCRIPTION
## Summary
- add a two-step merchant/store selector for the global write review entry
- keep review creation store-scoped by requiring a selected store before entering the form
- fix pending review routing so profile and merchant detail entries pass the correct merchant/store context

## Verification
- `npm run test:run -- src/features/customer/shared/layout/BottomNav/__tests__/BottomNav.test.tsx src/features/customer/profile/services/__tests__/profileService.test.ts src/features/customer/profile/pages/__tests__/ProfilePage.test.tsx src/features/customer/profile/components/__tests__/PendingReviewMerchants.test.tsx src/features/customer/reviews/services/__tests__/writeReviewTargetService.test.ts src/features/customer/reviews/pages/__tests__/WriteReviewPage.test.tsx src/features/customer/reviews/pages/__tests__/WriteReviewSelectPage.test.tsx src/features/customer/reviews/contexts/__tests__/ReviewContextDraft.test.tsx src/features/customer/reviews/contexts/__tests__/ReviewContextSubmit.test.tsx src/features/customer/pages/MerchantDetailPage/components/__tests__/RestaurantDetail.test.tsx`
- `npm run build`

Closes #167