### PR TITLE
feat(web): support multi-image store menu upload and gallery (#169)

### DIFF
--- a/docs/plans/2026-04-18-store-menu-images.md
+++ b/docs/plans/2026-04-18-store-menu-images.md
@@ -1,0 +1,271 @@
+# Store Menu Images Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Let merchants upload multiple menu images per store and let customers view those uploaded menu images on the store detail page.
+
+**Architecture:** Add a dedicated `menu_images` JSON field to the backend `stores` model and expose it through the existing store create/update/detail responses. Keep the merchant UI on the existing `/merchant/profile` page, but hydrate it from the owned store API and persist only the store-backed fields needed for menu images. Replace the customer menu mock with real `store.menu_images` rendering while preserving the current empty-state behavior when no images exist.
+
+**Tech Stack:** Go, Gin, GORM, React, TypeScript, Vitest
+
+---
+
+### Task 1: Add backend test coverage for `menu_images`
+
+**Files:**
+- Modify: `/home/wayne/Desktop/workspace/repos/revieu-backend/.worktrees/feat-store-menu-images/apps/core/internal/domain/store/service/service_test.go`
+- Modify: `/home/wayne/Desktop/workspace/repos/revieu-backend/.worktrees/feat-store-menu-images/apps/core/internal/router/openapi_v1_test.go`
+
+**Step 1: Write a failing service test for create/detail/update**
+
+Add a new service test that:
+- creates a store with `MenuImages: []string{"https://cdn.test/menu-1.jpg"}`
+- verifies the stored `menu_images` JSON is persisted
+- updates the store with a replacement slice like `[]string{"https://cdn.test/menu-a.jpg", "https://cdn.test/menu-b.jpg"}`
+- reloads the store and verifies the updated JSON exactly matches the new slice
+
+**Step 2: Run only the new backend service test and verify RED**
+
+Run:
+
+```bash
+go test ./internal/domain/store/service -run TestStoreServiceMenuImages -v
+```
+
+Expected: fail because `menu_images` is not yet modeled in the DTO/model/service.
+
+**Step 3: Write a failing API test for public detail + merchant patch**
+
+Add an API test that:
+- creates a merchant-owned store
+- `PATCH /api/v1/merchant/stores/:id` with `menu_images`
+- `POST /api/v1/merchant/stores/:id/activate`
+- `GET /api/v1/stores/:id`
+- asserts the response contains `menu_images` with the uploaded URLs
+
+**Step 4: Run only the new API test and verify RED**
+
+Run:
+
+```bash
+go test ./internal/router -run TestStoreMenuImages -v
+```
+
+Expected: fail because request/response payloads do not yet support `menu_images`.
+
+### Task 2: Implement backend `menu_images`
+
+**Files:**
+- Modify: `/home/wayne/Desktop/workspace/repos/revieu-backend/.worktrees/feat-store-menu-images/apps/core/internal/model/store.go`
+- Modify: `/home/wayne/Desktop/workspace/repos/revieu-backend/.worktrees/feat-store-menu-images/apps/core/internal/domain/store/dto/store.go`
+- Modify: `/home/wayne/Desktop/workspace/repos/revieu-backend/.worktrees/feat-store-menu-images/apps/core/internal/domain/store/service/service.go`
+- Modify: `/home/wayne/Desktop/workspace/repos/revieu-backend/.worktrees/feat-store-menu-images/apps/core/cmd/app/migrate.go` only if needed for migration model coverage
+
+**Step 1: Add the model field**
+
+Add:
+
+```go
+MenuImages string `gorm:"type:jsonb;default:'[]'" json:"menu_images"`
+```
+
+to `model.Store`.
+
+**Step 2: Add DTO request fields**
+
+Add:
+
+```go
+MenuImages []string `json:"menu_images"`
+```
+
+to `CreateStoreRequest` and:
+
+```go
+MenuImages *[]string `json:"menu_images"`
+```
+
+to `UpdateStoreRequest`.
+
+**Step 3: Persist the JSON**
+
+In `StoreService.Create` and `StoreService.Update`:
+- marshal `req.MenuImages`
+- write the JSON string into `menu_images`
+- leave existing `images` behavior unchanged
+
+**Step 4: Run targeted backend tests and verify GREEN**
+
+Run:
+
+```bash
+go test ./internal/domain/store/service -run TestStoreServiceMenuImages -v
+go test ./internal/router -run TestStoreMenuImages -v
+```
+
+Expected: both pass.
+
+### Task 3: Add frontend tests for merchant profile menu image persistence
+
+**Files:**
+- Create: `/home/wayne/Desktop/workspace/repos/revieu-web/.worktrees/feat-store-menu-images/src/features/merchant/profile/pages/__tests__/StoreProfile.test.tsx`
+- Create or modify: `/home/wayne/Desktop/workspace/repos/revieu-web/.worktrees/feat-store-menu-images/src/features/merchant/profile/services/storeProfileService.ts`
+
+**Step 1: Write a failing test for loading menu images**
+
+Test that `StoreProfile`:
+- loads the first owned store from `/merchant/stores?limit=1`
+- shows its `menu_images`
+- renders an empty state when the store has no `menu_images`
+
+**Step 2: Write a failing test for saving menu images**
+
+Test that clicking save after editing menu images sends:
+
+```json
+{ "menu_images": ["https://cdn.revieu.com/menu-1.jpg", "..."] }
+```
+
+to `PATCH /merchant/stores/:id`.
+
+**Step 3: Run the new merchant profile tests and verify RED**
+
+Run:
+
+```bash
+npm run test:run -- src/features/merchant/profile/pages/__tests__/StoreProfile.test.tsx
+```
+
+Expected: fail because `StoreProfile` is still using local mock state only.
+
+### Task 4: Implement merchant-side menu image persistence
+
+**Files:**
+- Modify: `/home/wayne/Desktop/workspace/repos/revieu-web/.worktrees/feat-store-menu-images/src/features/merchant/profile/pages/StoreProfile.tsx`
+- Create: `/home/wayne/Desktop/workspace/repos/revieu-web/.worktrees/feat-store-menu-images/src/features/merchant/profile/services/storeProfileService.ts`
+- Modify: `/home/wayne/Desktop/workspace/repos/revieu-web/.worktrees/feat-store-menu-images/src/features/merchant/profile/index.ts` only if exports are needed
+
+**Step 1: Add a small store profile service**
+
+Implement helpers to:
+- fetch `GET /merchant/stores?limit=1`
+- patch `PATCH /merchant/stores/:id`
+- normalize `menu_images` into `string[]`
+
+**Step 2: Hydrate `StoreProfile` from the API**
+
+Replace the hard-coded `mockStoreData` initialization path with:
+- loading state
+- error state
+- data mapped from the first owned store
+
+Keep the rest of the screen functional, but only persist the supported store-backed fields you need now.
+
+**Step 3: Persist menu image edits**
+
+On save:
+- send `menu_images`
+- update local state from the saved response
+- keep the existing add/edit/delete interactions for multiple images
+
+**Step 4: Run the merchant profile tests and verify GREEN**
+
+Run:
+
+```bash
+npm run test:run -- src/features/merchant/profile/pages/__tests__/StoreProfile.test.tsx
+```
+
+Expected: pass.
+
+### Task 5: Add frontend tests for customer menu rendering
+
+**Files:**
+- Modify: `/home/wayne/Desktop/workspace/repos/revieu-web/.worktrees/feat-store-menu-images/src/features/customer/pages/MerchantDetailPage/__tests__/RestaurantDetail.test.tsx`
+
+**Step 1: Write a failing test for menu image rendering**
+
+Test that after the store detail response includes:
+
+```json
+"menu_images": ["https://cdn.revieu.com/menu-1.jpg", "https://cdn.revieu.com/menu-2.jpg"]
+```
+
+the menu tab:
+- shows the uploaded images
+- does not show the old mocked message
+
+**Step 2: Write a failing test for empty state**
+
+Test that when `menu_images` is empty, the menu tab shows a clear “no menu uploaded yet” state.
+
+**Step 3: Run the customer menu tests and verify RED**
+
+Run:
+
+```bash
+npm run test:run -- src/features/customer/pages/MerchantDetailPage/__tests__/RestaurantDetail.test.tsx
+```
+
+Expected: fail because the customer menu tab still renders the mocked placeholder.
+
+### Task 6: Implement customer-side menu image rendering
+
+**Files:**
+- Modify: `/home/wayne/Desktop/workspace/repos/revieu-web/.worktrees/feat-store-menu-images/src/features/customer/pages/MerchantDetailPage/components/RestaurantDetail.tsx`
+- Reuse if helpful: `/home/wayne/Desktop/workspace/repos/revieu-web/.worktrees/feat-store-menu-images/src/features/customer/pages/MerchantDetailPage/components/MenuUploadWidget.tsx`
+
+**Step 1: Extend the store shape**
+
+Parse `menu_images` from the store detail payload into `string[]`.
+
+**Step 2: Replace the mocked menu placeholder**
+
+Render:
+- a small gallery/grid when `menu_images.length > 0`
+- the existing image zoom/view behavior if `MenuUploadWidget` can be reused cleanly
+- a simple empty state when there are no uploaded menu images
+
+**Step 3: Run the customer tests and verify GREEN**
+
+Run:
+
+```bash
+npm run test:run -- src/features/customer/pages/MerchantDetailPage/__tests__/RestaurantDetail.test.tsx
+```
+
+Expected: pass.
+
+### Task 7: Final verification
+
+**Files:**
+- Verify only; no file edits
+
+**Step 1: Run backend verification**
+
+Run:
+
+```bash
+go test ./internal/domain/store/...
+go test ./internal/router -run 'TestStore(MenuImages|Detail|Create|Update)' -v
+```
+
+**Step 2: Run frontend verification**
+
+Run:
+
+```bash
+npm run test:run -- src/features/merchant/profile/pages/__tests__/StoreProfile.test.tsx src/features/customer/pages/MerchantDetailPage/__tests__/RestaurantDetail.test.tsx src/features/customer/pages/MerchantDetailPage/__tests__/MerchantReviewsPage.test.tsx
+npm run build
+```
+
+**Step 3: Manual API smoke check if needed**
+
+After the backend is running with schema changes applied, verify:
+
+```bash
+curl -sS -i http://localhost:8080/api/v1/stores/<id>
+curl -sS -i http://localhost:8080/api/v1/merchant/stores?limit=1
+```
+
+Confirm `menu_images` is present in both relevant payloads.

--- a/src/features/customer/pages/MerchantDetailPage/__tests__/RestaurantDetail.test.tsx
+++ b/src/features/customer/pages/MerchantDetailPage/__tests__/RestaurantDetail.test.tsx
@@ -50,6 +50,8 @@ describe('RestaurantDetail', () => {
           country: 'USA',
           phone: '(512) 555-0278',
           cover_image_url: 'https://img.example/cover.jpg',
+          menu_images:
+            '["https://cdn.revieu.com/menus/taco-board.jpg","https://cdn.revieu.com/menus/brunch-board.jpg"]',
           avg_rating: 4.5,
           review_count: 1,
         },
@@ -105,6 +107,32 @@ describe('RestaurantDetail', () => {
     expect(screen.queryByText(/Reviews are not wired into this page yet/i)).not.toBeInTheDocument();
   });
 
+  it('renders uploaded menu images when the menu tab is opened', async () => {
+    const { RestaurantDetail } = await import('../components/RestaurantDetail');
+
+    render(
+      <MemoryRouter>
+        <RestaurantDetail storeId="278" />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText('Lone Star Taco Bar')).toBeInTheDocument();
+
+    fireEvent.click(screen.getAllByRole('button', { name: /menu/i })[0]);
+
+    expect(await screen.findByAltText('Menu image 1')).toHaveAttribute(
+      'src',
+      'https://cdn.revieu.com/menus/taco-board.jpg'
+    );
+    expect(screen.getByAltText('Menu image 2')).toHaveAttribute(
+      'src',
+      'https://cdn.revieu.com/menus/brunch-board.jpg'
+    );
+    expect(
+      screen.queryByText(/Menu data is still mocked in the frontend/i)
+    ).not.toBeInTheDocument();
+  });
+
   it('renders a real empty state in the reviews tab when the api returns no reviews', async () => {
     listStoreReviewsMock.mockResolvedValue({
       data: [],
@@ -123,5 +151,41 @@ describe('RestaurantDetail', () => {
     fireEvent.click(screen.getAllByRole('button', { name: /reviews/i })[0]);
 
     expect(await screen.findByText('No reviews for this store yet.')).toBeInTheDocument();
+  });
+
+  it('renders an empty state when the store has not uploaded menu images yet', async () => {
+    mockGet.mockResolvedValueOnce({
+      data: {
+        data: {
+          id: 278,
+          merchant_id: 202,
+          name: 'Lone Star Taco Bar',
+          description: 'Austin-style tacos, aguas frescas, and weekend brunch.',
+          address: '501 Congress Ave',
+          city: 'Austin',
+          state: 'TX',
+          country: 'USA',
+          phone: '(512) 555-0278',
+          cover_image_url: 'https://img.example/cover.jpg',
+          menu_images: '[]',
+          avg_rating: 4.5,
+          review_count: 1,
+        },
+      },
+    });
+
+    const { RestaurantDetail } = await import('../components/RestaurantDetail');
+
+    render(
+      <MemoryRouter>
+        <RestaurantDetail storeId="278" />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText('Lone Star Taco Bar')).toBeInTheDocument();
+
+    fireEvent.click(screen.getAllByRole('button', { name: /menu/i })[0]);
+
+    expect(await screen.findByText('No menu images uploaded yet.')).toBeInTheDocument();
   });
 });

--- a/src/features/customer/pages/MerchantDetailPage/components/RestaurantDetail.tsx
+++ b/src/features/customer/pages/MerchantDetailPage/components/RestaurantDetail.tsx
@@ -26,6 +26,7 @@ interface BackendStore {
   country?: string | null;
   phone?: string | null;
   cover_image_url?: string | null;
+  menu_images?: string[] | string | null;
   avg_rating?: number | null;
   review_count?: number | null;
 }
@@ -38,6 +39,7 @@ interface StoreDetail {
   address: string;
   phone: string;
   coverImageUrl: string;
+  menuImages: string[];
   rating: number;
   reviewCount: number;
 }
@@ -55,8 +57,35 @@ const FALLBACK_STORE: StoreDetail = {
   address: 'Store details will appear here after the backend lookup succeeds.',
   phone: '',
   coverImageUrl: FALLBACK_HERO,
+  menuImages: [],
   rating: 0,
   reviewCount: 0,
+};
+
+const parseStringArray = (value: string[] | string | null | undefined): string[] => {
+  if (Array.isArray(value)) {
+    return value.filter((item): item is string => typeof item === 'string' && item.trim().length > 0);
+  }
+
+  if (typeof value !== 'string') {
+    return [];
+  }
+
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return [];
+  }
+
+  try {
+    const parsed = JSON.parse(trimmed);
+    if (Array.isArray(parsed)) {
+      return parsed.filter((item): item is string => typeof item === 'string' && item.trim().length > 0);
+    }
+  } catch {
+    // Some responses may already contain a plain URL string.
+  }
+
+  return [trimmed];
 };
 
 const mapStore = (raw: BackendStore): StoreDetail => {
@@ -70,6 +99,7 @@ const mapStore = (raw: BackendStore): StoreDetail => {
     address: addressParts.join(', ') || 'Address unavailable',
     phone: raw.phone ?? '',
     coverImageUrl: raw.cover_image_url || FALLBACK_HERO,
+    menuImages: parseStringArray(raw.menu_images),
     rating: raw.avg_rating ?? 0,
     reviewCount: raw.review_count ?? 0,
   };
@@ -345,8 +375,32 @@ export function RestaurantDetail({ storeId, onBack }: RestaurantDetailProps) {
         )}
 
         {activeTab === 'menu' && (
-          <div className="mt-8 rounded-3xl border border-dashed border-gray-200 bg-gray-50 px-5 py-8 text-center text-sm text-gray-500">
-            Menu data is still mocked in the frontend. The store detail and coupon APIs are now live; menu integration can be done next.
+          <div className="mt-8 space-y-4">
+            <div className="flex items-center justify-between">
+              <h2 className="text-xl font-bold text-gray-900">Menu Photos</h2>
+              {isLoading && <span className="text-sm text-gray-400">Loading...</span>}
+            </div>
+
+            {store.menuImages.length === 0 ? (
+              <div className="rounded-3xl border border-dashed border-gray-200 bg-gray-50 px-5 py-8 text-center text-sm text-gray-500">
+                No menu images uploaded yet.
+              </div>
+            ) : (
+              <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                {store.menuImages.map((image, index) => (
+                  <div
+                    key={`${image}-${index}`}
+                    className="overflow-hidden rounded-3xl border border-gray-200 bg-white shadow-sm"
+                  >
+                    <ImageWithFallback
+                      src={image}
+                      alt={`Menu image ${index + 1}`}
+                      className="aspect-[4/3] w-full object-cover"
+                    />
+                  </div>
+                ))}
+              </div>
+            )}
           </div>
         )}
 

--- a/src/features/merchant/profile/pages/StoreProfile.tsx
+++ b/src/features/merchant/profile/pages/StoreProfile.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import {
   MapPin,
   Phone,
@@ -17,6 +17,12 @@ import InteractiveMap from '../../shared/components/InteractiveMap';
 import ConfirmationDialog from '../../shared/components/ConfirmationDialog';
 import MenuItemModal from '../../shared/components/MenuItemModal';
 import { DEFAULT_MERCHANT_ASSETS } from '../../shared/constants/defaults';
+import {
+  MerchantStoreRecord,
+  storeProfileService,
+  parseStringArray,
+  uploadMerchantImages,
+} from '../services/storeProfileService';
 
 // TypeScript interfaces
 interface MenuItem {
@@ -30,10 +36,14 @@ interface MenuItem {
 }
 
 interface StoreData {
+  id: string;
   name: string;
   phone: string;
   website: string;
-  address: string;
+  streetAddress: string;
+  city: string;
+  state: string;
+  country: string;
   coordinates: { lat: number; lng: number };
   coverPhoto: string;
   gallery: string[];
@@ -53,18 +63,18 @@ interface StoreData {
 
 // Mock data for McDonald's USC
 const mockStoreData: StoreData = {
+  id: '',
   name: "McDonald's - USC Figueroa",
   phone: "+1 (213) 749-1444",
   website: "https://www.mcdonalds.com/location/ca/los-angeles/3037-s-figueroa-st/",
-  address: "3037 S Figueroa St, Los Angeles, CA 90007",
+  streetAddress: "3037 S Figueroa St",
+  city: 'Los Angeles',
+  state: 'CA',
+  country: 'USA',
   coordinates: { lat: 34.0253, lng: -118.2831 },
   coverPhoto: DEFAULT_MERCHANT_ASSETS.COVER_PHOTO, // Use default cover photo
-  gallery: DEFAULT_MERCHANT_ASSETS.DEFAULT_GALLERY, // Use default gallery
-  menuImages: [
-    "https://images.unsplash.com/photo-1504674900247-0877df9cc836?w=400&h=300&fit=crop", // Menu board
-    "https://images.unsplash.com/photo-1414235077428-338989a2e8c0?w=400&h=300&fit=crop", // Restaurant menu
-    "https://images.unsplash.com/photo-1551218808-94e220e084d2?w=400&h=300&fit=crop"  // Digital menu display
-  ],
+  gallery: [],
+  menuImages: [],
   bio: "Welcome to the heart of the Trojan community! Serving USC students and local residents 24/7. We offer high-speed Wi-Fi, ample indoor seating, and the classic taste you love. Perfect for late-night study sessions or pre-game meals.",
   operatingHours: {
     open: "06:00",
@@ -113,9 +123,53 @@ const categoryColors: Record<string, string> = {
   "Drinks": "bg-orange-100 text-orange-800"
 };
 
+const formatAddress = (store: Pick<StoreData, 'streetAddress' | 'city' | 'state' | 'country'>) =>
+  [store.streetAddress, store.city, store.state, store.country].filter(Boolean).join(', ');
+
+const normalizeStoreData = (raw: MerchantStoreRecord, base: StoreData = mockStoreData): StoreData => ({
+  ...base,
+  id: String(raw.id),
+  name: raw.name ?? base.name,
+  phone: raw.phone ?? '',
+  website: raw.website ?? '',
+  streetAddress: raw.address ?? '',
+  city: raw.city ?? '',
+  state: raw.state ?? '',
+  country: raw.country ?? '',
+  coordinates: {
+    lat: raw.latitude ?? base.coordinates.lat,
+    lng: raw.longitude ?? base.coordinates.lng,
+  },
+  coverPhoto: raw.cover_image_url || DEFAULT_MERCHANT_ASSETS.COVER_PHOTO,
+  gallery: parseStringArray(raw.images),
+  menuImages: parseStringArray(raw.menu_images),
+  bio: raw.description ?? '',
+});
+
+const buildStoreUpdatePayload = (store: StoreData) => ({
+  name: store.name,
+  description: store.bio,
+  address: store.streetAddress,
+  city: store.city,
+  state: store.state,
+  country: store.country,
+  phone: store.phone,
+  website: store.website,
+  latitude: store.coordinates.lat,
+  longitude: store.coordinates.lng,
+  cover_image_url: store.coverPhoto,
+  images: store.gallery,
+  menu_images: store.menuImages,
+});
+
 const StoreProfile: React.FC = () => {
   const [isEditing, setIsEditing] = useState(false);
   const [storeData, setStoreData] = useState(mockStoreData);
+  const [savedStoreData, setSavedStoreData] = useState(mockStoreData);
+  const [isLoadingStore, setIsLoadingStore] = useState(true);
+  const [isSaving, setIsSaving] = useState(false);
+  const [isUploadingImages, setIsUploadingImages] = useState(false);
+  const [statusMessage, setStatusMessage] = useState<string | null>(null);
   const [confirmDialog, setConfirmDialog] = useState<{
     isOpen: boolean;
     title: string;
@@ -138,54 +192,156 @@ const StoreProfile: React.FC = () => {
     item: null
   });
 
-  const handleSave = () => {
-    setIsEditing(false);
-    // Here you would typically save to backend
+  useEffect(() => {
+    let cancelled = false;
+
+    const loadStore = async () => {
+      setIsLoadingStore(true);
+      setStatusMessage(null);
+
+      try {
+        const primaryStore = await storeProfileService.getPrimaryStore();
+        if (cancelled) {
+          return;
+        }
+
+        if (!primaryStore) {
+          setStatusMessage('No merchant store found yet.');
+          setStoreData(mockStoreData);
+          setSavedStoreData(mockStoreData);
+          return;
+        }
+
+        const normalizedStore = normalizeStoreData(primaryStore, mockStoreData);
+        setStoreData(normalizedStore);
+        setSavedStoreData(normalizedStore);
+      } catch (error) {
+        if (!cancelled) {
+          console.error('Failed to load store profile:', error);
+          setStatusMessage('Failed to load your store profile.');
+        }
+      } finally {
+        if (!cancelled) {
+          setIsLoadingStore(false);
+        }
+      }
+    };
+
+    void loadStore();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const handleSave = async () => {
+    if (!storeData.id) {
+      setStatusMessage('Store context is missing.');
+      return;
+    }
+
+    setIsSaving(true);
+    setStatusMessage(null);
+
+    try {
+      const updatedStore = await storeProfileService.updateStore(
+        storeData.id,
+        buildStoreUpdatePayload(storeData)
+      );
+      const normalizedStore = normalizeStoreData(updatedStore, storeData);
+      setStoreData(normalizedStore);
+      setSavedStoreData(normalizedStore);
+      setIsEditing(false);
+    } catch (error) {
+      console.error('Failed to save store profile:', error);
+      setStatusMessage('Failed to save store profile.');
+    } finally {
+      setIsSaving(false);
+    }
   };
 
   const handleCancel = () => {
     setIsEditing(false);
-    setStoreData(mockStoreData); // Reset to original data
+    setStatusMessage(null);
+    setStoreData(savedStoreData);
   };
 
-  const handleFileUpload = (event: React.ChangeEvent<HTMLInputElement>, type: 'cover' | 'gallery' | 'menuImages') => {
-    const file = event.target.files?.[0];
-    if (file) {
-      const reader = new FileReader();
-      reader.onload = (e) => {
-        const result = e.target?.result as string;
+  const handleFileUpload = async (
+    event: React.ChangeEvent<HTMLInputElement>,
+    type: 'cover' | 'gallery' | 'menuImages'
+  ) => {
+    const files = Array.from(event.target.files ?? []);
+    event.target.value = '';
+
+    if (files.length === 0) {
+      return;
+    }
+
+    setIsUploadingImages(true);
+    setStatusMessage(null);
+
+    try {
+      const uploadedUrls = await uploadMerchantImages(
+        type === 'cover' ? [files[0]] : files
+      );
+
+      setStoreData((prev) => {
         if (type === 'cover') {
-          setStoreData(prev => ({ ...prev, coverPhoto: result }));
-        } else if (type === 'gallery') {
-          // For gallery, add to existing images
-          setStoreData(prev => ({
+          return {
             ...prev,
-            gallery: [...prev.gallery, result]
-          }));
-        } else if (type === 'menuImages') {
-          // For menu images, add to existing images
-          setStoreData(prev => ({
-            ...prev,
-            menuImages: [...prev.menuImages, result]
-          }));
+            coverPhoto: uploadedUrls[0] ?? prev.coverPhoto,
+          };
         }
-      };
-      reader.readAsDataURL(file);
+
+        if (type === 'gallery') {
+          return {
+            ...prev,
+            gallery: [...prev.gallery, ...uploadedUrls],
+          };
+        }
+
+        return {
+          ...prev,
+          menuImages: [...prev.menuImages, ...uploadedUrls],
+        };
+      });
+    } catch (error) {
+      console.error('Failed to upload images:', error);
+      setStatusMessage('Failed to upload images.');
+    } finally {
+      setIsUploadingImages(false);
     }
   };
 
-  const handleGalleryImageEdit = (index: number, event: React.ChangeEvent<HTMLInputElement>) => {
+  const handleGalleryImageEdit = async (
+    index: number,
+    event: React.ChangeEvent<HTMLInputElement>
+  ) => {
     const file = event.target.files?.[0];
-    if (file) {
-      const reader = new FileReader();
-      reader.onload = (e) => {
-        const result = e.target?.result as string;
-        setStoreData(prev => ({
-          ...prev,
-          gallery: prev.gallery.map((img, i) => i === index ? result : img)
-        }));
-      };
-      reader.readAsDataURL(file);
+    event.target.value = '';
+
+    if (!file) {
+      return;
+    }
+
+    setIsUploadingImages(true);
+    setStatusMessage(null);
+
+    try {
+      const [uploadedUrl] = await uploadMerchantImages([file]);
+      if (!uploadedUrl) {
+        return;
+      }
+
+      setStoreData((prev) => ({
+        ...prev,
+        gallery: prev.gallery.map((img, i) => (i === index ? uploadedUrl : img)),
+      }));
+    } catch (error) {
+      console.error('Failed to replace gallery image:', error);
+      setStatusMessage('Failed to upload images.');
+    } finally {
+      setIsUploadingImages(false);
     }
   };
 
@@ -199,22 +355,40 @@ const StoreProfile: React.FC = () => {
           ...prev,
           gallery: prev.gallery.filter((_, i) => i !== index)
         }));
+        closeConfirmDialog();
       }
     });
   };
 
-  const handleMenuImageEdit = (index: number, event: React.ChangeEvent<HTMLInputElement>) => {
+  const handleMenuImageEdit = async (
+    index: number,
+    event: React.ChangeEvent<HTMLInputElement>
+  ) => {
     const file = event.target.files?.[0];
-    if (file) {
-      const reader = new FileReader();
-      reader.onload = (e) => {
-        const result = e.target?.result as string;
-        setStoreData(prev => ({
-          ...prev,
-          menuImages: prev.menuImages.map((img, i) => i === index ? result : img)
-        }));
-      };
-      reader.readAsDataURL(file);
+    event.target.value = '';
+
+    if (!file) {
+      return;
+    }
+
+    setIsUploadingImages(true);
+    setStatusMessage(null);
+
+    try {
+      const [uploadedUrl] = await uploadMerchantImages([file]);
+      if (!uploadedUrl) {
+        return;
+      }
+
+      setStoreData((prev) => ({
+        ...prev,
+        menuImages: prev.menuImages.map((img, i) => (i === index ? uploadedUrl : img)),
+      }));
+    } catch (error) {
+      console.error('Failed to replace menu image:', error);
+      setStatusMessage('Failed to upload images.');
+    } finally {
+      setIsUploadingImages(false);
     }
   };
 
@@ -228,6 +402,7 @@ const StoreProfile: React.FC = () => {
           ...prev,
           menuImages: prev.menuImages.filter((_, i) => i !== index)
         }));
+        closeConfirmDialog();
       }
     });
   };
@@ -243,6 +418,7 @@ const StoreProfile: React.FC = () => {
           ...prev,
           menu: prev.menu.filter(item => item.id !== itemId)
         }));
+        closeConfirmDialog();
       }
     });
   };
@@ -345,12 +521,14 @@ const StoreProfile: React.FC = () => {
         <div className="flex items-center justify-between">
           <div>
             <h1 className="text-2xl font-bold text-gray-900">{storeData.name}</h1>
+            {isLoadingStore && <p className="mt-1 text-sm text-gray-500">Loading store profile...</p>}
           </div>
           <div className="flex gap-2">
             {isEditing ? (
               <>
                 <button
                   onClick={handleCancel}
+                  disabled={isSaving || isUploadingImages}
                   className="flex items-center gap-2 px-4 py-2 text-gray-600 bg-white border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors"
                 >
                   <X size={16} />
@@ -358,16 +536,18 @@ const StoreProfile: React.FC = () => {
                 </button>
                 <button
                   onClick={handleSave}
+                  disabled={isSaving || isUploadingImages}
                   className="flex items-center gap-2 px-4 py-2 text-white bg-yellow-500 rounded-lg hover:bg-yellow-600 transition-colors"
                   style={{ backgroundColor: '#FFBC0D' }}
                 >
                   <Save size={16} />
-                  Save Changes
+                  {isSaving ? 'Saving...' : 'Save Changes'}
                 </button>
               </>
             ) : (
               <button
                 onClick={() => setIsEditing(true)}
+                disabled={isLoadingStore}
                 className="flex items-center gap-2 px-4 py-2 text-white bg-yellow-500 rounded-lg hover:bg-yellow-600 transition-colors"
                 style={{ backgroundColor: '#FFBC0D' }}
               >
@@ -377,6 +557,12 @@ const StoreProfile: React.FC = () => {
             )}
           </div>
         </div>
+
+        {statusMessage && (
+          <div className="rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800">
+            {statusMessage}
+          </div>
+        )}
 
         {/* Cover Photo */}
         <div className="bg-white rounded-xl shadow-sm border border-gray-200 overflow-hidden">
@@ -676,13 +862,13 @@ const StoreProfile: React.FC = () => {
                 <MapPin size={16} className="text-gray-400 mt-1" />
                 {isEditing ? (
                   <textarea
-                    value={storeData.address}
-                    onChange={(e) => setStoreData({ ...storeData, address: e.target.value })}
+                    value={storeData.streetAddress}
+                    onChange={(e) => setStoreData({ ...storeData, streetAddress: e.target.value })}
                     className="flex-1 px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-yellow-500 focus:border-transparent"
                     rows={2}
                   />
                 ) : (
-                  <p className="text-gray-900">{storeData.address}</p>
+                  <p className="text-gray-900">{formatAddress(storeData)}</p>
                 )}
               </div>
             </div>
@@ -691,7 +877,7 @@ const StoreProfile: React.FC = () => {
             <InteractiveMap
               lat={storeData.coordinates.lat}
               lng={storeData.coordinates.lng}
-              address={storeData.address}
+              address={formatAddress(storeData)}
               isEditing={isEditing}
             />
           </div>
@@ -803,6 +989,7 @@ const StoreProfile: React.FC = () => {
                 <input
                   type="file"
                   accept="image/*"
+                  multiple
                   onChange={(e) => handleFileUpload(e, 'menuImages')}
                   className="hidden"
                 />
@@ -867,6 +1054,7 @@ const StoreProfile: React.FC = () => {
                   <input
                     type="file"
                     accept="image/*"
+                    multiple
                     onChange={(e) => handleFileUpload(e, 'menuImages')}
                     className="hidden"
                   />

--- a/src/features/merchant/profile/pages/__tests__/StoreProfile.test.tsx
+++ b/src/features/merchant/profile/pages/__tests__/StoreProfile.test.tsx
@@ -1,0 +1,137 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockGet, mockPatch } = vi.hoisted(() => ({
+  mockGet: vi.fn(),
+  mockPatch: vi.fn(),
+}));
+
+vi.mock('../../../../../api/apiClient', () => ({
+  apiClient: {
+    get: mockGet,
+    patch: mockPatch,
+  },
+}));
+
+vi.mock('../../../shared/components/InteractiveMap', () => ({
+  default: () => <div data-testid="interactive-map" />,
+}));
+
+vi.mock('../../../shared/components/ConfirmationDialog', () => ({
+  default: ({
+    isOpen,
+    onConfirm,
+    onClose,
+    title,
+  }: {
+    isOpen: boolean;
+    onConfirm: () => void;
+    onClose: () => void;
+    title: string;
+  }) =>
+    isOpen ? (
+      <div>
+        <p>{title}</p>
+        <button type="button" onClick={onConfirm}>
+          Confirm
+        </button>
+        <button type="button" onClick={onClose}>
+          Close
+        </button>
+      </div>
+    ) : null,
+}));
+
+vi.mock('../../../shared/components/MenuItemModal', () => ({
+  default: () => null,
+}));
+
+describe('StoreProfile', () => {
+  beforeEach(() => {
+    mockGet.mockReset();
+    mockPatch.mockReset();
+
+    mockGet.mockResolvedValue({
+      data: {
+        data: [
+          {
+            id: 320,
+            name: 'Northline Brunch Club - North Beach',
+            phone: '(415) 555-3401',
+            website: 'https://demo.revieu.local/northline/north',
+            address: '1800 Stockton St',
+            city: 'San Francisco',
+            state: 'CA',
+            country: 'USA',
+            latitude: 37.8032,
+            longitude: -122.4091,
+            cover_image_url: 'https://cdn.revieu.com/store-cover.jpg',
+            images: '[]',
+            menu_images:
+              '["https://cdn.revieu.com/menu-1.jpg","https://cdn.revieu.com/menu-2.jpg"]',
+            description: 'Brunch flagship.',
+          },
+        ],
+      },
+    });
+    mockPatch.mockResolvedValue({
+      data: {
+        data: {
+          id: 320,
+          name: 'Northline Brunch Club - North Beach',
+          phone: '(415) 555-3401',
+          website: 'https://demo.revieu.local/northline/north',
+          address: '1800 Stockton St',
+          city: 'San Francisco',
+          state: 'CA',
+          country: 'USA',
+          latitude: 37.8032,
+          longitude: -122.4091,
+          cover_image_url: 'https://cdn.revieu.com/store-cover.jpg',
+          images: '[]',
+          menu_images: '["https://cdn.revieu.com/menu-2.jpg"]',
+          description: 'Brunch flagship.',
+        },
+      },
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('loads the first merchant store and renders its uploaded menu images', async () => {
+    const { default: StoreProfile } = await import('../StoreProfile');
+
+    render(<StoreProfile />);
+
+    await waitFor(() => {
+      expect(mockGet).toHaveBeenCalledWith('/merchant/stores?limit=1');
+    });
+
+    expect(await screen.findAllByText('Northline Brunch Club - North Beach')).toHaveLength(2);
+    expect(screen.getByAltText('Menu 1')).toHaveAttribute('src', 'https://cdn.revieu.com/menu-1.jpg');
+    expect(screen.getByAltText('Menu 2')).toHaveAttribute('src', 'https://cdn.revieu.com/menu-2.jpg');
+    expect(screen.queryByText('McDonald\'s - USC Figueroa')).not.toBeInTheDocument();
+  });
+
+  it('persists menu image changes back to the owned store', async () => {
+    const { default: StoreProfile } = await import('../StoreProfile');
+
+    render(<StoreProfile />);
+
+    expect(await screen.findAllByText('Northline Brunch Club - North Beach')).toHaveLength(2);
+
+    fireEvent.click(screen.getByRole('button', { name: /edit profile/i }));
+    fireEvent.click(screen.getAllByTitle('Delete menu image')[0]);
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm' }));
+    fireEvent.click(screen.getByRole('button', { name: /save changes/i }));
+
+    await waitFor(() => {
+      expect(mockPatch).toHaveBeenCalledWith('/merchant/stores/320', expect.objectContaining({
+        menu_images: ['https://cdn.revieu.com/menu-2.jpg'],
+      }));
+    });
+  });
+});

--- a/src/features/merchant/profile/services/storeProfileService.ts
+++ b/src/features/merchant/profile/services/storeProfileService.ts
@@ -1,0 +1,108 @@
+import { apiClient } from '../../../../api/apiClient';
+import { mediaApi, uploadToR2 } from '../../../../api/media';
+
+export interface MerchantStoreRecord {
+  id: number;
+  name?: string | null;
+  description?: string | null;
+  address?: string | null;
+  city?: string | null;
+  state?: string | null;
+  country?: string | null;
+  phone?: string | null;
+  website?: string | null;
+  latitude?: number | null;
+  longitude?: number | null;
+  cover_image_url?: string | null;
+  images?: string[] | string | null;
+  menu_images?: string[] | string | null;
+}
+
+export interface UpdateMerchantStorePayload {
+  name?: string;
+  description?: string;
+  address?: string;
+  city?: string;
+  state?: string;
+  country?: string;
+  phone?: string;
+  website?: string;
+  latitude?: number;
+  longitude?: number;
+  cover_image_url?: string;
+  images?: string[];
+  menu_images?: string[];
+}
+
+const isNonEmptyString = (value: unknown): value is string =>
+  typeof value === 'string' && value.trim().length > 0;
+
+export const parseStringArray = (value: string[] | string | null | undefined): string[] => {
+  if (Array.isArray(value)) {
+    return value.filter(isNonEmptyString);
+  }
+
+  if (typeof value !== 'string') {
+    return [];
+  }
+
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return [];
+  }
+
+  try {
+    const parsed = JSON.parse(trimmed);
+    if (Array.isArray(parsed)) {
+      return parsed.filter(isNonEmptyString);
+    }
+  } catch {
+    // Some existing responses may already contain a plain URL string.
+  }
+
+  return trimmed ? [trimmed] : [];
+};
+
+export const uploadMerchantImages = async (files: File[]): Promise<string[]> => {
+  if (files.length === 0) {
+    return [];
+  }
+
+  const uploadUrlsResponse = await mediaApi.getUploadUrls({
+    files: files.map((file) => ({
+      filename: file.name,
+      contentType: file.type || 'application/octet-stream',
+    })),
+  });
+
+  const uploadedUrls = new Array<string>(uploadUrlsResponse.uploads.length);
+
+  await Promise.all(
+    uploadUrlsResponse.uploads.map(async (upload, index) => {
+      await uploadToR2(upload.uploadUrl, files[index]);
+      uploadedUrls[index] = upload.fileUrl;
+    })
+  );
+
+  return uploadedUrls.filter(isNonEmptyString);
+};
+
+export const storeProfileService = {
+  async getPrimaryStore(): Promise<MerchantStoreRecord | null> {
+    const response = await apiClient.get<{ data: MerchantStoreRecord[] }>('/merchant/stores?limit=1');
+    return response.data.data[0] ?? null;
+  },
+
+  async updateStore(
+    storeId: string,
+    payload: UpdateMerchantStorePayload
+  ): Promise<MerchantStoreRecord> {
+    const response = await apiClient.patch<{ data: MerchantStoreRecord }>(
+      `/merchant/stores/${storeId}`,
+      payload
+    );
+
+    return response.data.data;
+  },
+};
+


### PR DESCRIPTION
## Summary
- load the merchant-owned store profile from the live merchant stores endpoint
- upload and save multiple store-level menu images through the existing media upload flow
- render live menu photos on the customer store detail page instead of mock menu content

## Test Plan
- npm run test:run -- src/features/customer/pages/MerchantDetailPage/__tests__/MerchantReviewsPage.test.tsx src/features/customer/shared/layout/BottomNav/__tests__/BottomNav.test.tsx src/features/merchant/profile/pages/__tests__/StoreProfile.test.tsx src/features/customer/pages/MerchantDetailPage/__tests__/RestaurantDetail.test.tsx
- npm run build

Closes #169